### PR TITLE
nearby 브랜치를 main 브랜치에 머지하는 과정에서 생긴 충돌 이슈를 해결하였습니다. 

### DIFF
--- a/Kindy/Kindy.xcodeproj/project.pbxproj
+++ b/Kindy/Kindy.xcodeproj/project.pbxproj
@@ -20,6 +20,9 @@
 		6EE5E3F628FECF4200EA7413 /* CurationDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE5E3F528FECF4200EA7413 /* CurationDetail.swift */; };
 		6EE5E3F828FECFA300EA7413 /* CurationDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE5E3F728FECFA300EA7413 /* CurationDetailCell.swift */; };
 		6EE5E3FC28FEF11700EA7413 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE5E3FB28FEF11700EA7413 /* UIViewController+.swift */; };
+		77DCB14A290297C100EAB5D5 /* NearbyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB149290297C100EAB5D5 /* NearbyCell.swift */; };
+		77DCB14D2902982700EAB5D5 /* NearbyDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB14C2902982700EAB5D5 /* NearbyDummy.swift */; };
+		77DCB1502902987700EAB5D5 /* NearbyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB14F2902987700EAB5D5 /* NearbyViewController.swift */; };
 		7B404C1328FE889200A24C89 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B404C1228FE889200A24C89 /* UIColor+.swift */; };
 		7B404C1528FE88BD00A24C89 /* ResourcesFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B404C1428FE88BD00A24C89 /* ResourcesFile.swift */; };
 		7B404C1728FE88DC00A24C89 /* ProtocolFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B404C1628FE88DC00A24C89 /* ProtocolFile.swift */; };
@@ -52,6 +55,9 @@
 		6EE5E3F528FECF4200EA7413 /* CurationDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationDetail.swift; sourceTree = "<group>"; };
 		6EE5E3F728FECFA300EA7413 /* CurationDetailCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurationDetailCell.swift; sourceTree = "<group>"; };
 		6EE5E3FB28FEF11700EA7413 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
+		77DCB149290297C100EAB5D5 /* NearbyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyCell.swift; sourceTree = "<group>"; };
+		77DCB14C2902982700EAB5D5 /* NearbyDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyDummy.swift; sourceTree = "<group>"; };
+		77DCB14F2902987700EAB5D5 /* NearbyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyViewController.swift; sourceTree = "<group>"; };
 		7B404C1228FE889200A24C89 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		7B404C1428FE88BD00A24C89 /* ResourcesFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourcesFile.swift; sourceTree = "<group>"; };
 		7B404C1628FE88DC00A24C89 /* ProtocolFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolFile.swift; sourceTree = "<group>"; };
@@ -132,12 +138,29 @@
 			path = Curation;
 			sourceTree = "<group>";
 		};
+		77DCB14B290297F100EAB5D5 /* Nearby */ = {
+			isa = PBXGroup;
+			children = (
+				77DCB149290297C100EAB5D5 /* NearbyCell.swift */,
+			);
+			path = Nearby;
+			sourceTree = "<group>";
+		};
+		77DCB14E2902983100EAB5D5 /* Nearby */ = {
+			isa = PBXGroup;
+			children = (
+				77DCB14C2902982700EAB5D5 /* NearbyDummy.swift */,
+			);
+			path = Nearby;
+			sourceTree = "<group>";
+		};
 		7B404C0B28FE87D300A24C89 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
 				6EE5E39E28FD313C00EA7413 /* HomeViewController.swift */,
 				6EE5E3AE28FD318A00EA7413 /* MyPageViewController.swift */,
 				6EE5E3F028FECEE900EA7413 /* CurationViewController.swift */,
+				77DCB14F2902987700EAB5D5 /* NearbyViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -147,6 +170,7 @@
 			children = (
 				7B404C2D29016C7500A24C89 /* Supplementary */,
 				7B404C2C29016BDF00A24C89 /* Home */,
+				77DCB14B290297F100EAB5D5 /* Nearby */,
 				6EE5E3F228FECEF700EA7413 /* Curation */,
 			);
 			path = Views;
@@ -155,6 +179,7 @@
 		7B404C0D28FE87EA00A24C89 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				77DCB14E2902983100EAB5D5 /* Nearby */,
 				6EE5E3ED28FECEC000EA7413 /* Curation */,
 				7B404C2028FFAA7900A24C89 /* TempCuration.swift */,
 				7B404C1A28FE89BA00A24C89 /* Bookstore.swift */,
@@ -289,6 +314,8 @@
 				7B404C1B28FE89BA00A24C89 /* Bookstore.swift in Sources */,
 				7B404C2528FFD33500A24C89 /* CurationCollectionViewCell.swift in Sources */,
 				6EE5E3F428FECF1300EA7413 /* CurationMainView.swift in Sources */,
+				77DCB14D2902982700EAB5D5 /* NearbyDummy.swift in Sources */,
+				77DCB1502902987700EAB5D5 /* NearbyViewController.swift in Sources */,
 				7B404C1B28FE89BA00A24C89 /* Bookstore.swift in Sources */,
 				7B404C1D28FE8E3000A24C89 /* Region.swift in Sources */,
 				7B404C1728FE88DC00A24C89 /* ProtocolFile.swift in Sources */,
@@ -299,6 +326,7 @@
 				6EE5E39D28FD313C00EA7413 /* SceneDelegate.swift in Sources */,
 				6EE5E3FC28FEF11700EA7413 /* UIViewController+.swift in Sources */,
 				6EE5E3F628FECF4200EA7413 /* CurationDetail.swift in Sources */,
+				77DCB14A290297C100EAB5D5 /* NearbyCell.swift in Sources */,
 				7B404C3129017C7300A24C89 /* SectionHeaderDelegate.swift in Sources */,
 				6EE5E3F828FECFA300EA7413 /* CurationDetailCell.swift in Sources */,
 				7B404C2F29016CAF00A24C89 /* SectionHeaderView.swift in Sources */,

--- a/Kindy/Kindy/Controllers/NearbyViewController.swift
+++ b/Kindy/Kindy/Controllers/NearbyViewController.swift
@@ -1,0 +1,193 @@
+//
+//  NearbyViewController.swift
+//  Kindy
+//
+//  Created by Park Kangwook on 2022/10/19.
+//
+
+// TODO: 더미데이터 삭제 후 기존 모델 데이터와 연결 | UITable, UIbutton extension 따로 빼기 | extensinon 빼서 정리, PR
+// 이외 ToDoList는 코드 속에 있으니 참조
+
+import UIKit
+
+class NearbyViewController: UIViewController, UISearchResultsUpdating {
+    
+    // MARK: - 프로퍼티
+    
+    private var tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .grouped)
+        tableView.backgroundColor = .white
+        
+        return tableView
+    }()
+    
+    // 검색된 프로퍼티 담을 배열 생성 (초기값은 전체가 담겨있는 배열) -> 이 기준으로 cell 나타낼 것이기 때문에 DataSource, Delegate에 이 프로퍼티 적용
+    var filteredItems: [Dummy] = dummyList
+    
+    let searchController = UISearchController()
+    
+    // MARK: - 라이프 사이클
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupSearchController()
+        setupTableView()
+        
+        dismissKeyboard()
+    }
+    
+    // MARK: - 메소드
+    
+    func setupTableView() {
+        view.addSubview(tableView)
+        tableView.dataSource = self
+        tableView.delegate = self
+        
+        tableView.register(NearbyCell.self, forCellReuseIdentifier: NearbyCell.reuseID)   // Cell 등록 (코드 베이스라서)
+        tableView.rowHeight = NearbyCell.rowHeight
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    // SearchController에 대한 설정들
+    private func setupSearchController() {
+        navigationItem.searchController = searchController
+        searchController.obscuresBackgroundDuringPresentation = false
+        searchController.searchResultsUpdater = self
+        navigationItem.hidesSearchBarWhenScrolling = false
+    }
+    
+    // 서치바에 타이핑될 때 어떻게 할 건지 설정하는 함수 (유저의 검색에 반응하는 로직)
+    func updateSearchResults(for searchController: UISearchController) {
+        if let searchString = searchController.searchBar.text, searchString.isEmpty == false {
+            filteredItems = dummyList.filter{ (item) -> Bool in
+                item.name!.localizedCaseInsensitiveContains(searchString)
+            }
+        } else {
+            filteredItems = dummyList
+        }
+        
+        tableView.reloadData()
+    }
+}
+
+// MARK: - DataSource
+
+extension NearbyViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        filteredItems.count == 0 ? tableView.setEmptyView(text: "현재 계신 곳 주변에 독립서점 정보가 없어요") : tableView.restore()
+        
+        return filteredItems.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: NearbyCell.reuseID, for: indexPath) as? NearbyCell else { return UITableViewCell() }
+        cell.bookstore = filteredItems[indexPath.row]
+        
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return filteredItems.count == 0 ? nil : "총 \(filteredItems.count)개"
+    }
+}
+
+// MARK: - Delegate
+
+extension NearbyViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        
+        // TODO: 서점 상세 페이지 연결
+        /* let detailVC = DetailViewController()
+        detailVC.bookstoreLbl.text = filteredItems[indexPath.row].name!
+        navigationController?.pushViewController(detailVC, animated: true) */
+        
+        print("\(filteredItems[indexPath.row].name!) 상세 페이지 연결")
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+}
+
+// MARK: - Empty View
+
+extension UITableView {
+    func setEmptyView(text message: String) {
+        let messageLabel: UILabel = {
+            let label = UILabel()
+            label.text = message
+            label.textColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)
+            label.font = UIFont(name: "AppleSDGothicNeo-Regular", size: 15)
+            label.textAlignment = .center
+            label.sizeToFit()
+            label.translatesAutoresizingMaskIntoConstraints = false
+            
+            return label
+        }()
+        
+        let reportButton: UIButton = {
+            let btn = UIButton()
+            btn.setTitle("독립서점 제보하기", for: .normal)
+            btn.setTitleColor(UIColor(red: 0.173, green: 0.459, blue: 0.355, alpha: 1), for: .normal)
+            btn.titleLabel?.font = UIFont(name: "AppleSDGothicNeo-Bold", size: 17)
+            btn.translatesAutoresizingMaskIntoConstraints = false
+            btn.addTarget(self, action: #selector(reportButtonTapped), for: .touchUpInside)
+            btn.setUnderline()
+            
+            return btn
+        }()
+        
+        let emptyView : UIView = {
+            let view = UIView()
+            [messageLabel, reportButton].forEach{ view.addSubview($0) }
+            NSLayoutConstraint.activate([
+                messageLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                messageLabel.centerYAnchor.constraint(equalTo: view.topAnchor, constant: 200),  // TODO: 서치바 기준으로 잡기
+                reportButton.centerXAnchor.constraint(equalTo: messageLabel.centerXAnchor),
+                reportButton.topAnchor.constraint(equalTo: messageLabel.topAnchor, constant: 26)
+            ])
+            
+            return view
+        }()
+        
+        self.backgroundView = emptyView
+    }
+    
+    func restore() {
+        self.backgroundView = nil
+    }
+    
+    // TODO: '독립서점 제보하기' 버튼 액션 구현 (메일 앱으로 넘어가기)
+    @objc func reportButtonTapped() {
+        print("메일 앱으로 넘어가는 기능 구현하기")
+    }
+}
+
+// button에 underline 주기 위한 extension
+extension UIButton {
+    func setUnderline() {
+        guard let title = title(for: .normal) else { return }
+        let attributedString = NSMutableAttributedString(string: title)
+        attributedString.addAttribute(.underlineStyle,
+                                      value: NSUnderlineStyle.single.rawValue,
+                                      range: NSRange(location: 0, length: title.count))
+        setAttributedTitle(attributedString, for: .normal)
+    }
+}
+
+extension UIViewController {
+    func dismissKeyboard() {
+        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+    
+    @objc func hideKeyboard() {
+        self.view.window?.endEditing(true)
+    }
+}

--- a/Kindy/Kindy/Models/Nearby/NearbyDummy.swift
+++ b/Kindy/Kindy/Models/Nearby/NearbyDummy.swift
@@ -1,0 +1,27 @@
+//
+//  NearbyDummy.swift
+//  Kindy
+//
+//  Created by Park Kangwook on 2022/10/20.
+//
+
+import Foundation
+
+struct Dummy {
+    let name, address, openTime, closeTime : String?
+    let meterDistance, timeDistance : Int?
+}
+
+let dummyList: [Dummy] = [
+    Dummy(name: "달팽이 책방1", address: "경북 포항시 남구 효자동길10번길 32", openTime: "13:00", closeTime: "19:30", meterDistance: 900, timeDistance: 10),
+    Dummy(name: "달팽이 책방2", address: "경북 포항시 남구 효자동길10번길 32", openTime: "13:00", closeTime: "19:30", meterDistance: 900, timeDistance: 10),
+    Dummy(name: "달팽이 책방3", address: "경북 포항시 남구 효자동길10번길 32", openTime: "13:00", closeTime: "19:30", meterDistance: 900, timeDistance: 10),
+    Dummy(name: "달팽이 책방4", address: "경북 포항시 남구 효자동길10번길 32", openTime: "13:00", closeTime: "19:30", meterDistance: 900, timeDistance: 10),
+    Dummy(name: "달팽이 책방5", address: "경북 포항시 남구 효자동길10번길 32", openTime: "13:00", closeTime: "19:30", meterDistance: 900, timeDistance: 10),
+    Dummy(name: "달팽이 책방6", address: "경북 포항시 남구 효자동길10번길 32", openTime: "13:00", closeTime: "19:30", meterDistance: 900, timeDistance: 10),
+    Dummy(name: "달팽이 책방7", address: "경북 포항시 남구 효자동길10번길 32", openTime: "13:00", closeTime: "19:30", meterDistance: 900, timeDistance: 10),
+    Dummy(name: "달팽이 책방8", address: "경북 포항시 남구 효자동길10번길 32", openTime: "13:00", closeTime: "19:30", meterDistance: 900, timeDistance: 10),
+    Dummy(name: "달팽이 책방9", address: "경북 포항시 남구 효자동길10번길 32", openTime: "13:00", closeTime: "19:30", meterDistance: 900, timeDistance: 10),
+    Dummy(name: "달팽이 책방10", address: "경북 포항시 남구 효자동길10번길 32", openTime: "13:00", closeTime: "19:30", meterDistance: 900, timeDistance: 10),
+    Dummy(name: "달팽이 책방11", address: "경북 포항시 남구 효자동길10번길 32", openTime: "13:00", closeTime: "19:30", meterDistance: 900, timeDistance: 10),
+]

--- a/Kindy/Kindy/Views/Nearby/NearbyCell.swift
+++ b/Kindy/Kindy/Views/Nearby/NearbyCell.swift
@@ -1,0 +1,124 @@
+//
+//  NearbyCell.swift
+//  Kindy
+//
+//  Created by Park Kangwook on 2022/10/20.
+//
+
+import UIKit
+
+class NearbyCell: UITableViewCell {
+
+    static let reuseID = "NearMeListCell"
+    static let rowHeight: CGFloat = 136     // Cell 길이
+    
+    var bookstore: Dummy? {
+        didSet {
+            configureCell(item: bookstore!)
+        }
+    }
+    
+    // MARK: - Cell 프로퍼티
+    
+    // 서점 사진
+    private let photoImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            imageView.widthAnchor.constraint(equalToConstant: 104),
+            imageView.heightAnchor.constraint(equalToConstant: 104)
+        ])
+        
+        imageView.layer.cornerRadius = 8
+        imageView.clipsToBounds = true      // radius를 imageView에 적용
+        imageView.backgroundColor = .lightGray      // 사진 없을 경우 default 색
+        
+        return imageView
+    }()
+
+    // 서점 이름
+    private let nameLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont(name: "AppleSDGothicNeo-Bold", size: 17)
+        label.text = ""
+
+        return label
+    }()
+    
+    // 서점 상세 주소
+    private let addressLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont(name: "AppleSDGothicNeo-Regular", size: 15)
+        label.textColor = UIColor(red: 0.459, green: 0.459, blue: 0.459, alpha: 1)
+        label.text = ""
+        
+        return label
+    }()
+    
+    // 서점까지의 거리
+    private let distanceLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont(name: "AppleSDGothicNeo-Regular", size: 17)
+        label.textColor = UIColor(red: 0.173, green: 0.459, blue: 0.355, alpha: 1)
+        label.text = ""
+        
+        return label
+    }()
+    
+    // 레이블들 감싸는 stack
+    private let infoStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = 7   // 피그마에 적혀있는 4 적용하니 좁아보임. 7로 적용하니 피그마에 있는 비율과 비슷
+        stack.alignment = .leading
+        
+        return stack
+    }()
+    
+    // MARK: - Cell 메소드
+    
+    private func setup() {
+        [photoImageView, infoStackView].forEach { contentView.addSubview($0) }
+        [nameLabel, addressLabel, distanceLabel].forEach { infoStackView.addArrangedSubview($0) }
+        
+        NSLayoutConstraint.activate([
+            photoImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            photoImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            
+            infoStackView.leadingAnchor.constraint(equalTo: photoImageView.trailingAnchor, constant: 16),
+            infoStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
+        ])
+    }
+    
+    private func configureCell(item: Dummy) {
+        nameLabel.text = item.name
+        addressLabel.text = item.address
+        distanceLabel.text = "\(item.meterDistance!)m"
+//        photoImageView.image = item.image?[0] ?? nil   // 첫번째 사진이 대표 사진
+    }
+    
+    // MARK: - 라이프 사이클
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        setup()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        photoImageView.image = nil
+        nameLabel.text = nil
+        distanceLabel.text = nil
+    }
+}


### PR DESCRIPTION
# 배경
- `main` 브랜치에 `nearby` 브랜치를 머지하는 과정에서 생긴 충돌 이슈를 해결하였습니다. 
- 아마도 `nearby` 에서 쓰던 더미 데이터 모델과 `main` 에서 쓰던 모델 사이에 겹치는 이름이 있어서 충돌이 발생한 것으로 예상됩니다.
- 따라서 `nearby` 의 더미 데이터를 수정하였습니다.

# 작업 내용
- `NearbyDummy` 파일에서 구조체 이름을 변경하였습니다. ( `Bookstore` -> `Dummy` )
- 더미 데이터 배열 이름을 변경하였습니다. ( `bookstores` -> `dummyList` )
- 추가로, `/Controllers/Nearby `폴더에 있던 3개의 파일 ( `NearbyViewController`, `NearbyDummy`, `NearbyCell` ) 을 각각 알맞은 위치로 변경하였습니다. 
- `/Controllers/NearbyViewController`
- `/Models/Nearby/NearbyDummy`
- `/Views/Nearby/NearbyCell`
