### PR TITLE
🍿 NearbyViewController 에서 쓰인 extension들을 분리하여 Extensions 폴더에 정리하였습니다. ( dismissKeyboard, setEmptyView, setUnderline ) 

### DIFF
--- a/Kindy/Kindy.xcodeproj/project.pbxproj
+++ b/Kindy/Kindy.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		77DCB14A290297C100EAB5D5 /* NearbyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB149290297C100EAB5D5 /* NearbyCell.swift */; };
 		77DCB14D2902982700EAB5D5 /* NearbyDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB14C2902982700EAB5D5 /* NearbyDummy.swift */; };
 		77DCB1502902987700EAB5D5 /* NearbyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB14F2902987700EAB5D5 /* NearbyViewController.swift */; };
+		77DCB15229029CF500EAB5D5 /* UITableView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB15129029CF500EAB5D5 /* UITableView+.swift */; };
+		77DCB15429029D1F00EAB5D5 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB15329029D1F00EAB5D5 /* UIButton+.swift */; };
 		7B404C1328FE889200A24C89 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B404C1228FE889200A24C89 /* UIColor+.swift */; };
 		7B404C1528FE88BD00A24C89 /* ResourcesFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B404C1428FE88BD00A24C89 /* ResourcesFile.swift */; };
 		7B404C1728FE88DC00A24C89 /* ProtocolFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B404C1628FE88DC00A24C89 /* ProtocolFile.swift */; };
@@ -58,6 +60,8 @@
 		77DCB149290297C100EAB5D5 /* NearbyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyCell.swift; sourceTree = "<group>"; };
 		77DCB14C2902982700EAB5D5 /* NearbyDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyDummy.swift; sourceTree = "<group>"; };
 		77DCB14F2902987700EAB5D5 /* NearbyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyViewController.swift; sourceTree = "<group>"; };
+		77DCB15129029CF500EAB5D5 /* UITableView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+.swift"; sourceTree = "<group>"; };
+		77DCB15329029D1F00EAB5D5 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		7B404C1228FE889200A24C89 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		7B404C1428FE88BD00A24C89 /* ResourcesFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourcesFile.swift; sourceTree = "<group>"; };
 		7B404C1628FE88DC00A24C89 /* ProtocolFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolFile.swift; sourceTree = "<group>"; };
@@ -203,6 +207,8 @@
 			children = (
 				7B404C1228FE889200A24C89 /* UIColor+.swift */,
 				6EE5E3FB28FEF11700EA7413 /* UIViewController+.swift */,
+				77DCB15129029CF500EAB5D5 /* UITableView+.swift */,
+				77DCB15329029D1F00EAB5D5 /* UIButton+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -325,6 +331,7 @@
 				7B404C1F28FE90B700A24C89 /* Item.swift in Sources */,
 				6EE5E39D28FD313C00EA7413 /* SceneDelegate.swift in Sources */,
 				6EE5E3FC28FEF11700EA7413 /* UIViewController+.swift in Sources */,
+				77DCB15429029D1F00EAB5D5 /* UIButton+.swift in Sources */,
 				6EE5E3F628FECF4200EA7413 /* CurationDetail.swift in Sources */,
 				77DCB14A290297C100EAB5D5 /* NearbyCell.swift in Sources */,
 				7B404C3129017C7300A24C89 /* SectionHeaderDelegate.swift in Sources */,
@@ -334,6 +341,7 @@
 				7B404C1328FE889200A24C89 /* UIColor+.swift in Sources */,
 				6EE5E3EF28FECECE00EA7413 /* CurationMain.swift in Sources */,
 				6EE5E3F128FECEE900EA7413 /* CurationViewController.swift in Sources */,
+				77DCB15229029CF500EAB5D5 /* UITableView+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Kindy/Kindy/Controllers/NearbyViewController.swift
+++ b/Kindy/Kindy/Controllers/NearbyViewController.swift
@@ -22,9 +22,9 @@ class NearbyViewController: UIViewController, UISearchResultsUpdating {
     }()
     
     // 검색된 프로퍼티 담을 배열 생성 (초기값은 전체가 담겨있는 배열) -> 이 기준으로 cell 나타낼 것이기 때문에 DataSource, Delegate에 이 프로퍼티 적용
-    var filteredItems: [Dummy] = dummyList
+    private var filteredItems: [Dummy] = dummyList
     
-    let searchController = UISearchController()
+    private let searchController = UISearchController()
     
     // MARK: - 라이프 사이클
     
@@ -39,7 +39,7 @@ class NearbyViewController: UIViewController, UISearchResultsUpdating {
     
     // MARK: - 메소드
     
-    func setupTableView() {
+    private func setupTableView() {
         view.addSubview(tableView)
         tableView.dataSource = self
         tableView.delegate = self
@@ -111,83 +111,5 @@ extension NearbyViewController: UITableViewDelegate {
         
         print("\(filteredItems[indexPath.row].name!) 상세 페이지 연결")
         tableView.deselectRow(at: indexPath, animated: true)
-    }
-}
-
-// MARK: - Empty View
-
-extension UITableView {
-    func setEmptyView(text message: String) {
-        let messageLabel: UILabel = {
-            let label = UILabel()
-            label.text = message
-            label.textColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)
-            label.font = UIFont(name: "AppleSDGothicNeo-Regular", size: 15)
-            label.textAlignment = .center
-            label.sizeToFit()
-            label.translatesAutoresizingMaskIntoConstraints = false
-            
-            return label
-        }()
-        
-        let reportButton: UIButton = {
-            let btn = UIButton()
-            btn.setTitle("독립서점 제보하기", for: .normal)
-            btn.setTitleColor(UIColor(red: 0.173, green: 0.459, blue: 0.355, alpha: 1), for: .normal)
-            btn.titleLabel?.font = UIFont(name: "AppleSDGothicNeo-Bold", size: 17)
-            btn.translatesAutoresizingMaskIntoConstraints = false
-            btn.addTarget(self, action: #selector(reportButtonTapped), for: .touchUpInside)
-            btn.setUnderline()
-            
-            return btn
-        }()
-        
-        let emptyView : UIView = {
-            let view = UIView()
-            [messageLabel, reportButton].forEach{ view.addSubview($0) }
-            NSLayoutConstraint.activate([
-                messageLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-                messageLabel.centerYAnchor.constraint(equalTo: view.topAnchor, constant: 200),  // TODO: 서치바 기준으로 잡기
-                reportButton.centerXAnchor.constraint(equalTo: messageLabel.centerXAnchor),
-                reportButton.topAnchor.constraint(equalTo: messageLabel.topAnchor, constant: 26)
-            ])
-            
-            return view
-        }()
-        
-        self.backgroundView = emptyView
-    }
-    
-    func restore() {
-        self.backgroundView = nil
-    }
-    
-    // TODO: '독립서점 제보하기' 버튼 액션 구현 (메일 앱으로 넘어가기)
-    @objc func reportButtonTapped() {
-        print("메일 앱으로 넘어가는 기능 구현하기")
-    }
-}
-
-// button에 underline 주기 위한 extension
-extension UIButton {
-    func setUnderline() {
-        guard let title = title(for: .normal) else { return }
-        let attributedString = NSMutableAttributedString(string: title)
-        attributedString.addAttribute(.underlineStyle,
-                                      value: NSUnderlineStyle.single.rawValue,
-                                      range: NSRange(location: 0, length: title.count))
-        setAttributedTitle(attributedString, for: .normal)
-    }
-}
-
-extension UIViewController {
-    func dismissKeyboard() {
-        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
-        tap.cancelsTouchesInView = false
-        view.addGestureRecognizer(tap)
-    }
-    
-    @objc func hideKeyboard() {
-        self.view.window?.endEditing(true)
     }
 }

--- a/Kindy/Kindy/Extensions/UIButton+.swift
+++ b/Kindy/Kindy/Extensions/UIButton+.swift
@@ -1,0 +1,20 @@
+//
+//  UIButton+.swift
+//  Kindy
+//
+//  Created by Park Kangwook on 2022/10/21.
+//
+
+import UIKit
+
+// button에 underline 주기 위한 extension
+extension UIButton {
+    func setUnderline() {
+        guard let title = title(for: .normal) else { return }
+        let attributedString = NSMutableAttributedString(string: title)
+        attributedString.addAttribute(.underlineStyle,
+                                      value: NSUnderlineStyle.single.rawValue,
+                                      range: NSRange(location: 0, length: title.count))
+        setAttributedTitle(attributedString, for: .normal)
+    }
+}

--- a/Kindy/Kindy/Extensions/UITableView+.swift
+++ b/Kindy/Kindy/Extensions/UITableView+.swift
@@ -1,0 +1,60 @@
+//
+//  UITableView+.swift
+//  Kindy
+//
+//  Created by Park Kangwook on 2022/10/21.
+//
+
+import UIKit
+
+extension UITableView {
+    func setEmptyView(text message: String) {
+        let messageLabel: UILabel = {
+            let label = UILabel()
+            label.text = message
+            label.textColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)
+            label.font = UIFont(name: "AppleSDGothicNeo-Regular", size: 15)
+            label.textAlignment = .center
+            label.sizeToFit()
+            label.translatesAutoresizingMaskIntoConstraints = false
+            
+            return label
+        }()
+        
+        let reportButton: UIButton = {
+            let btn = UIButton()
+            btn.setTitle("독립서점 제보하기", for: .normal)
+            btn.setTitleColor(UIColor(red: 0.173, green: 0.459, blue: 0.355, alpha: 1), for: .normal)
+            btn.titleLabel?.font = UIFont(name: "AppleSDGothicNeo-Bold", size: 17)
+            btn.translatesAutoresizingMaskIntoConstraints = false
+            btn.addTarget(self, action: #selector(reportButtonTapped), for: .touchUpInside)
+            btn.setUnderline()
+            
+            return btn
+        }()
+        
+        let emptyView : UIView = {
+            let view = UIView()
+            [messageLabel, reportButton].forEach{ view.addSubview($0) }
+            NSLayoutConstraint.activate([
+                messageLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                messageLabel.centerYAnchor.constraint(equalTo: view.topAnchor, constant: 200),  // TODO: 서치바 기준으로 잡기
+                reportButton.centerXAnchor.constraint(equalTo: messageLabel.centerXAnchor),
+                reportButton.topAnchor.constraint(equalTo: messageLabel.topAnchor, constant: 26)
+            ])
+            
+            return view
+        }()
+        
+        self.backgroundView = emptyView
+    }
+    
+    func restore() {
+        self.backgroundView = nil
+    }
+    
+    // TODO: '독립서점 제보하기' 버튼 액션 구현 (메일 앱으로 넘어가기)
+    @objc func reportButtonTapped() {
+        print("메일 앱으로 넘어가는 기능 구현하기")
+    }
+}

--- a/Kindy/Kindy/Extensions/UIViewController+.swift
+++ b/Kindy/Kindy/Extensions/UIViewController+.swift
@@ -17,4 +17,14 @@ extension UIViewController {
         gradientLayer.endPoint = CGPoint(x: 0.5, y: 0.9)
         return gradientLayer
     }
+    
+    func dismissKeyboard() {
+        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+    
+    @objc func hideKeyboard() {
+        self.view.window?.endEditing(true)
+    }
 }


### PR DESCRIPTION
# 배경
- `NearbyViewController` 에서 쓰인 extension들을 분리하여 `Extensions` 폴더에 정리하였습니다.
- 커밋은 하나지만, 사용했던 extension 들을 모아볼 수 있도록 하나의 PR로 분리하였습니다. 
- `dismissKeyboard`, `setEmptyView`, `setUnderline` 메소드들이 있습니다.
# 작업 내용

### `dismissKeyboard()`
- 검색창에 입력 중 키보드가 올라왔을 때, 화면을 터치하면 키보드가 내려가는 메소드입니다.
- `/Extensions/UIViewController+` 파일에 정의되어 있습니다.
- 해당 VC 파일의 `viewDidLoad()` 메소드 내부에서 호출하시면 됩니다.

### `setEmptyView(text message: String)`
- 검색 결과가 없을 때 빈 결과 화면을 나타내는 메소드입니다.
- `/Extensions/UITableView+` 파일에 정의되어 있습니다.
- UITableView 의 DataSource 에서 cell 개수를 정의하는 곳에 메소드를 호출하시면 됩니다. 
- 나타내고자 하는 문구를 전달 인자 `text` 로 입력하시면 됩니다.
- 현재는 '독립서점 제보하기' 버튼이 있지만, 추후 이 문구도 유연하게 수정할 수 있도록 작업할 예정입니다.

### `setUnderline()`
- `UIButton`의 `title text` 에 밑줄을 그어주는 메소드입니다.
- /Extensions/UIButton+ 파일에 정의되어 있습니다.
- 버튼 프로퍼티를 생성하는 곳에서 메소드를 호출하시면 됩니다.

