### PR TITLE
홈 화면의 검색 이미지를 터치하면 이동하는 검색 페이지를 구현했습니다.

### DIFF
--- a/Kindy/Kindy.xcodeproj/project.pbxproj
+++ b/Kindy/Kindy.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		77DCB1612904457600EAB5D5 /* RegionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB1602904457600EAB5D5 /* RegionViewController.swift */; };
 		77DCB1632904462300EAB5D5 /* RegionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB1622904462300EAB5D5 /* RegionCell.swift */; };
 		77DCB1662904467B00EAB5D5 /* RegionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB1652904467B00EAB5D5 /* RegionHeaderView.swift */; };
+		77DCB1682905397E00EAB5D5 /* HomeSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB1672905397E00EAB5D5 /* HomeSearchViewController.swift */; };
 		7B404C1328FE889200A24C89 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B404C1228FE889200A24C89 /* UIColor+.swift */; };
 		7B404C1528FE88BD00A24C89 /* ResourcesFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B404C1428FE88BD00A24C89 /* ResourcesFile.swift */; };
 		7B404C1B28FE89BA00A24C89 /* Bookstore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B404C1A28FE89BA00A24C89 /* Bookstore.swift */; };
@@ -73,6 +74,7 @@
 		77DCB1602904457600EAB5D5 /* RegionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionViewController.swift; sourceTree = "<group>"; };
 		77DCB1622904462300EAB5D5 /* RegionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionCell.swift; sourceTree = "<group>"; };
 		77DCB1652904467B00EAB5D5 /* RegionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionHeaderView.swift; sourceTree = "<group>"; };
+		77DCB1672905397E00EAB5D5 /* HomeSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSearchViewController.swift; sourceTree = "<group>"; };
 		7B404C1228FE889200A24C89 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		7B404C1428FE88BD00A24C89 /* ResourcesFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourcesFile.swift; sourceTree = "<group>"; };
 		7B404C1A28FE89BA00A24C89 /* Bookstore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bookstore.swift; sourceTree = "<group>"; };
@@ -181,6 +183,7 @@
 			isa = PBXGroup;
 			children = (
 				6EE5E39E28FD313C00EA7413 /* HomeViewController.swift */,
+				77DCB1672905397E00EAB5D5 /* HomeSearchViewController.swift */,
 				6EE5E3AE28FD318A00EA7413 /* MyPageViewController.swift */,
 				6EE5E3F028FECEE900EA7413 /* CurationViewController.swift */,
 				361D54CE2901CABB00ACA11E /* DetailBookstoreViewController.swift */,
@@ -342,6 +345,7 @@
 				7B404C1528FE88BD00A24C89 /* ResourcesFile.swift in Sources */,
 				7B404C2B28FFD3CF00A24C89 /* RegionCollectionViewCell.swift in Sources */,
 				7B404C1B28FE89BA00A24C89 /* Bookstore.swift in Sources */,
+				77DCB1682905397E00EAB5D5 /* HomeSearchViewController.swift in Sources */,
 				7B404C2528FFD33500A24C89 /* CurationCollectionViewCell.swift in Sources */,
 				6EE5E3F428FECF1300EA7413 /* CurationMainView.swift in Sources */,
 				7B404C1B28FE89BA00A24C89 /* Bookstore.swift in Sources */,

--- a/Kindy/Kindy.xcodeproj/project.pbxproj
+++ b/Kindy/Kindy.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		77DCB1632904462300EAB5D5 /* RegionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB1622904462300EAB5D5 /* RegionCell.swift */; };
 		77DCB1662904467B00EAB5D5 /* RegionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB1652904467B00EAB5D5 /* RegionHeaderView.swift */; };
 		77DCB1682905397E00EAB5D5 /* HomeSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB1672905397E00EAB5D5 /* HomeSearchViewController.swift */; };
+		77DCB16A29053B9900EAB5D5 /* HomeSearchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB16929053B9900EAB5D5 /* HomeSearchCell.swift */; };
 		7B404C1328FE889200A24C89 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B404C1228FE889200A24C89 /* UIColor+.swift */; };
 		7B404C1528FE88BD00A24C89 /* ResourcesFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B404C1428FE88BD00A24C89 /* ResourcesFile.swift */; };
 		7B404C1B28FE89BA00A24C89 /* Bookstore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B404C1A28FE89BA00A24C89 /* Bookstore.swift */; };
@@ -75,6 +76,7 @@
 		77DCB1622904462300EAB5D5 /* RegionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionCell.swift; sourceTree = "<group>"; };
 		77DCB1652904467B00EAB5D5 /* RegionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionHeaderView.swift; sourceTree = "<group>"; };
 		77DCB1672905397E00EAB5D5 /* HomeSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSearchViewController.swift; sourceTree = "<group>"; };
+		77DCB16929053B9900EAB5D5 /* HomeSearchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSearchCell.swift; sourceTree = "<group>"; };
 		7B404C1228FE889200A24C89 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		7B404C1428FE88BD00A24C89 /* ResourcesFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourcesFile.swift; sourceTree = "<group>"; };
 		7B404C1A28FE89BA00A24C89 /* Bookstore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bookstore.swift; sourceTree = "<group>"; };
@@ -179,6 +181,14 @@
 			path = Region;
 			sourceTree = "<group>";
 		};
+		77DCB16B29053B9D00EAB5D5 /* HomeSearch */ = {
+			isa = PBXGroup;
+			children = (
+				77DCB16929053B9900EAB5D5 /* HomeSearchCell.swift */,
+			);
+			path = HomeSearch;
+			sourceTree = "<group>";
+		};
 		7B404C0B28FE87D300A24C89 /* View Controllers */ = {
 			isa = PBXGroup;
 			children = (
@@ -199,6 +209,7 @@
 				36B1B3832904102300C91825 /* DetailBookstoreView.swift */,
 				7B404C2D29016C7500A24C89 /* Supplementary */,
 				7B404C2C29016BDF00A24C89 /* Home */,
+				77DCB16B29053B9D00EAB5D5 /* HomeSearch */,
 				77DCB14B290297F100EAB5D5 /* Nearby */,
 				6EE5E3F228FECEF700EA7413 /* Curation */,
 				77DCB1642904462D00EAB5D5 /* Region */,
@@ -371,6 +382,7 @@
 				7B404C2F29016CAF00A24C89 /* SectionHeaderView.swift in Sources */,
 				77DCB1662904467B00EAB5D5 /* RegionHeaderView.swift in Sources */,
 				6EE5E3AF28FD318A00EA7413 /* MyPageViewController.swift in Sources */,
+				77DCB16A29053B9900EAB5D5 /* HomeSearchCell.swift in Sources */,
 				7B404C1328FE889200A24C89 /* UIColor+.swift in Sources */,
 				6EE5E3EF28FECECE00EA7413 /* CurationMain.swift in Sources */,
 				6EE5E3F128FECEE900EA7413 /* CurationViewController.swift in Sources */,

--- a/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
@@ -1,0 +1,50 @@
+//
+//  HomeSearchViewController.swift
+//  Kindy
+//
+//  Created by Park Kangwook on 2022/10/23.
+//
+
+import UIKit
+
+class HomeSearchViewController: UIViewController {
+
+    private var tableView: UITableView = {
+        let view = UITableView()
+        view.backgroundColor = .white
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupTableView()
+    }
+
+    private func setupTableView() {
+        view.addSubview(tableView)
+        
+        tableView.dataSource = self
+        tableView.delegate = self
+    }
+}
+
+// MARK: - data source
+
+extension HomeSearchViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 0
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        return UITableViewCell()
+    }
+    
+}
+
+// MARK: - delegate
+extension HomeSearchViewController: UITableViewDelegate {
+    
+}

--- a/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
@@ -38,6 +38,13 @@ final class HomeSearchViewController: UIViewController {
         tableView.delegate = self
         tableView.register(HomeSearchCell.self, forCellReuseIdentifier: HomeSearchCell.identifier)
         tableView.rowHeight = HomeSearchCell.rowHeight
+        
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
     }
 }
 

--- a/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
@@ -34,6 +34,16 @@ final class HomeSearchViewController: UIViewController, UISearchResultsUpdating 
         dismissKeyboard()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        DispatchQueue.main.async {  // must call from main thread
+            self.searchController.searchBar.becomeFirstResponder()
+        }
+        // 코드 출처 : https://stackoverflow.com/questions/31274058/make-uisearchcontroller-search-bar-automatically-active/
+        // 개념 이해 : https://stackoverflow.com/questions/27951965/cannot-set-searchbar-as-firstresponder
+    }
+    
     // MARK: - 메소드
     
     private func setupSearchController() {

--- a/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
@@ -41,6 +41,15 @@ final class HomeSearchViewController: UIViewController, UISearchResultsUpdating 
         searchController.obscuresBackgroundDuringPresentation = false
         searchController.searchResultsUpdater = self
         navigationItem.hidesSearchBarWhenScrolling = false
+        
+        customCancelButton()
+    }
+    
+    private func customCancelButton() {
+        searchController.searchBar.setValue("취소", forKey: "cancelButtonText")
+        searchController.searchBar.tintColor = UIColor(red: 0.173, green: 0.459, blue: 0.355, alpha: 1)
+        searchController.searchBar.placeholder = "서점 이름, 주소 검색"
+        searchController.searchBar.setShowsCancelButton(true, animated: true)
     }
     
     private func setupTableView() {

--- a/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
@@ -23,6 +23,8 @@ final class HomeSearchViewController: UIViewController, UISearchResultsUpdating 
     
     private let searchController = UISearchController()
     
+    private var searchText: String? = ""
+    
     // MARK: - 라이프 사이클
     
     override func viewDidLoad() {
@@ -82,11 +84,13 @@ final class HomeSearchViewController: UIViewController, UISearchResultsUpdating 
     
     func updateSearchResults(for searchController: UISearchController) {
         if let searchString = searchController.searchBar.text, searchString.isEmpty == false {
+            searchText = searchString
             filteredItems = dummyList.filter{ (item) -> Bool in
-                item.name!.localizedCaseInsensitiveContains(searchString)
+                item.name!.localizedCaseInsensitiveContains(searchText!)
             }
         } else {
-            filteredItems = dummyList
+            filteredItems = []
+            searchText = ""
         }
         
         tableView.reloadData()
@@ -97,7 +101,7 @@ final class HomeSearchViewController: UIViewController, UISearchResultsUpdating 
 
 extension HomeSearchViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        filteredItems.isEmpty ? tableView.setEmptyView(text: "찾으시는 서점이 없으신가요?") : tableView.restore()
+        filteredItems.isEmpty && searchText != "" ? tableView.setEmptyView(text: "찾으시는 서점이 없으신가요?") : tableView.restore()
         
         return filteredItems.count
     }

--- a/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
@@ -38,9 +38,11 @@ final class HomeSearchViewController: UIViewController, UISearchResultsUpdating 
     
     private func setupSearchController() {
         navigationItem.searchController = searchController
-        searchController.obscuresBackgroundDuringPresentation = false
+        self.navigationItem.hidesBackButton = true
+        searchController.searchBar.delegate = self
         searchController.searchResultsUpdater = self
         navigationItem.hidesSearchBarWhenScrolling = false
+        searchController.obscuresBackgroundDuringPresentation = false
         
         customCancelButton()
     }
@@ -114,5 +116,13 @@ extension HomeSearchViewController: UITableViewDelegate {
 
         print("\(filteredItems[indexPath.row].name!) 상세 페이지 연결")
         tableView.deselectRow(at: indexPath, animated: true)
+    }
+}
+
+// MARK: - 서치바 취소 버튼 delegate
+
+extension HomeSearchViewController: UISearchBarDelegate {
+    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+        self.navigationController?.popToRootViewController(animated: true)
     }
 }

--- a/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
@@ -7,15 +7,21 @@
 
 import UIKit
 
-class HomeSearchViewController: UIViewController {
+final class HomeSearchViewController: UIViewController {
 
+    // MARK: - 프로퍼티
+    
     private var tableView: UITableView = {
-        let view = UITableView()
+        let view = UITableView(frame: .zero, style: .grouped)
         view.backgroundColor = .white
         view.translatesAutoresizingMaskIntoConstraints = false
         
         return view
     }()
+    
+//    private var homeSearchCell = HomeSearchCell()
+    
+    // MARK: - 라이프 사이클
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -23,11 +29,15 @@ class HomeSearchViewController: UIViewController {
         setupTableView()
     }
 
+    // MARK: - 메소드
+    
     private func setupTableView() {
         view.addSubview(tableView)
-        
+
         tableView.dataSource = self
         tableView.delegate = self
+        tableView.register(HomeSearchCell.self, forCellReuseIdentifier: HomeSearchCell.identifier)
+        tableView.rowHeight = HomeSearchCell.rowHeight
     }
 }
 

--- a/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
@@ -19,7 +19,7 @@ final class HomeSearchViewController: UIViewController {
         return view
     }()
     
-//    private var homeSearchCell = HomeSearchCell()
+    private var filteredItems: [Dummy] = dummyList
     
     // MARK: - 라이프 사이클
     
@@ -49,7 +49,9 @@ extension HomeSearchViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        return UITableViewCell()
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: HomeSearchCell.identifier, for: indexPath) as? HomeSearchCell else { return UITableViewCell() }
+        
+        return cell
     }
     
 }

--- a/Kindy/Kindy/Views/HomeSearch/HomeSearchCell.swift
+++ b/Kindy/Kindy/Views/HomeSearch/HomeSearchCell.swift
@@ -12,6 +12,12 @@ final class HomeSearchCell: UITableViewCell {
     static let identifier = "HomeSearchCell"
     static let rowHeight: CGFloat = 96
     
+    var bookstore: Dummy? {
+        didSet {
+            configureCell(item: bookstore!)
+        }
+    }
+    
     // MARK: - 프로퍼티
     
     private var photoImageView: UIImageView = {
@@ -47,6 +53,10 @@ final class HomeSearchCell: UITableViewCell {
             nameLabel.centerYAnchor.constraint(equalTo: photoImageView.centerYAnchor),
             nameLabel.leadingAnchor.constraint(equalTo: photoImageView.trailingAnchor, constant: 16)
         ])
+    }
+    
+    private func configureCell(item: Dummy) {
+        nameLabel.text = item.name
     }
     
     // MARK: - 라이프 사이클

--- a/Kindy/Kindy/Views/HomeSearch/HomeSearchCell.swift
+++ b/Kindy/Kindy/Views/HomeSearch/HomeSearchCell.swift
@@ -1,0 +1,69 @@
+//
+//  HomeSearchCell.swift
+//  Kindy
+//
+//  Created by Park Kangwook on 2022/10/23.
+//
+
+import UIKit
+
+final class HomeSearchCell: UITableViewCell {
+
+    static let identifier = "HomeSearchCell"
+    static let rowHeight: CGFloat = 96
+    
+    // MARK: - 프로퍼티
+    
+    private var photoImageView: UIImageView = {
+        let view = UIImageView()
+        view.contentMode = .scaleAspectFill
+        view.layer.cornerRadius = 8
+        view.clipsToBounds = true      // radius를 imageView에 적용
+        view.backgroundColor = .lightGray
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    private var nameLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont(name: "AppleSDGothicNeo-Regular", size: 17)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    // MARK: - 메소드
+    
+    private func createLayout() {
+        [photoImageView, nameLabel].forEach { contentView.addSubview($0) }
+        
+        NSLayoutConstraint.activate([
+            photoImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            photoImageView.topAnchor.constraint(equalTo: topAnchor, constant: 16),
+            photoImageView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16),
+            photoImageView.widthAnchor.constraint(equalTo: photoImageView.heightAnchor),
+            
+            nameLabel.centerYAnchor.constraint(equalTo: photoImageView.centerYAnchor),
+            nameLabel.leadingAnchor.constraint(equalTo: photoImageView.trailingAnchor, constant: 16)
+        ])
+    }
+    
+    // MARK: - 라이프 사이클
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        createLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        photoImageView.image = nil
+        nameLabel.text = nil
+    }
+}


### PR DESCRIPTION
# 배경
### 검색 페이지 첫 작업
- 홈 화면의 검색 이미지를 터치하면 이동하는 검색 페이지를 새로 생성하고 작업하였습니다.
- 빠른 개발 속도를 초점으로 작업하였습니다.
- 그렇기에 새로운 개념 적용, 리팩토링은 추후 고려할 예정입니다.
- 하나의 PR로 구성하였습니다.

### MVC 패턴
- 생각보다 MVC 패턴을 적용하는 게 쉽지가 않습니다.
- 그래서 현재 코드에서 View, ViewController 코드의 분리가 깔끔하진 않습니다.
- 혹시 도와주실 분이 계신다면 같이 분리해보고 싶습니다.


# 작업 내용
- `View Controllers/` 위치에 `HomeSearchController` 파일 생성하였습니다.
- `Views/HomeSearch/` 위치에 `HomeSearchCell` 파일 생성하였습니다.
- 전체적 흐름이 `NearbyViewController`, `RegionViewController` 에 있는 검색 기능과 유사합니다.
- 차이점을 중점으로 설명하겠습니다.
- 코드 컨벤션에 맞춰서 작업하려 했지만, 아직 헷갈리는 부분이 있어 논의한 바와 상이할 수 있습니다.
- 세밀한 리팩토링은 다음 주에 진행할 예정입니다.


## 1. back 버튼 제거
- 피그마에 back 버튼이 없길래 hide 처리 해주었습니다.

## 2. 키보드 띄우기
- 피그마에 적혀있는 대로, 검색 화면에 들어가자마자 키보드를 띄웠습니다.
- `viewDidAppear` 메소드 내에서,
- `메인 쓰레드`로부터 `비동기적`으로 `searchController` 의 `becomeFirstResponder` 메소드를 호출합니다. 
- `viewDidAppear` 내에서 요청하는 이유는, 
- `searchController` 가 `active` 한 상태가 되어야 `becomeFirstResponder` 메소드가 작동하기 때문입니다.
- `becomeFirstResponder` 메소드의 의미는
- 해당 객체 ( `searchController` ) 를 first responder로 만들 것을 요청한다는 의미입니다.
- 그렇게 되면 키보드가 상승합니다.

## 3. empty view 분기 처리
- 원래는 검색한 텍스트가 없을 때도 empty view가 나오는 상황이었습니다.
- 검색 텍스트가 없을 때는 빈 화면이, 검색 텍스트가 있으면서 결과가 없을 때에는 empty view가 나오도록 했습니다.
- 이를 위해 `searchText` 라는 새로운 프로퍼티를 생성하고 기존의 `searchString` 을 할당했습니다.

## 4. 취소 버튼 custom, navigation
- default였던 cancel 버튼은 custom 하여 텍스트, 색 변경하였습니다.
- 취소 버튼을 누르면 `HomeViewController` 로 이동하기 위해 `UISearchBarDelegate` 를 사용했습니다.

# 스크린샷

https://user-images.githubusercontent.com/77043329/197398052-90969dc8-621d-45de-a643-3b66d0384ee5.mp4


