### PR TITLE
enum 초기화 함수를 추가함으로서, HomeView 나올때 데이터 업데이트 적용

### DIFF
--- a/Kindy/Kindy/Models/Item.swift
+++ b/Kindy/Kindy/Models/Item.swift
@@ -82,6 +82,10 @@ enum Item: Hashable {
     ]
     
     static func updateBookmarkedData() {
+        mainCuration = [
+            .mainCuration(NewItems.curationDummy[Int.random(in: 0..<NewItems.curationDummy.count)])
+        ]
+        curations = NewItems.curationDummy.filter{ $0.id != "1" }.map{ .curation($0) }
         nearByBookStores = NewItems.bookstoreDummy.sorted{ $0.name > $1.name }.map{ .bookStore($0) }
         bookmarkedBookStores = NewItems.bookstoreDummy.filter{ $0.isFavorite }.map{ .bookmarkedBookStore($0) }
     }

--- a/Kindy/Kindy/Models/Item.swift
+++ b/Kindy/Kindy/Models/Item.swift
@@ -82,6 +82,7 @@ enum Item: Hashable {
     ]
     
     static func updateBookmarkedData() {
+        nearByBookStores = NewItems.bookstoreDummy.sorted{ $0.name > $1.name }.map{ .bookStore($0) }
         bookmarkedBookStores = NewItems.bookstoreDummy.filter{ $0.isFavorite }.map{ .bookmarkedBookStore($0) }
     }
     

--- a/Kindy/Kindy/Models/Item.swift
+++ b/Kindy/Kindy/Models/Item.swift
@@ -9,11 +9,21 @@ import Foundation
 
 // 메인 Diffable Data Source에 쓰일 Item 열거형
 enum Item: Hashable {
+    case mainCuration(Curation)
     case curation(Curation)
     case bookStore(Bookstore)
+    case bookmarkedBookStore(Bookstore)
     case region(Region)
     case emptyNearby
     case emptyBookmark
+    
+    var mainCuration: Curation? {
+        if case .mainCuration(let mainCuration) = self {
+            return mainCuration
+        } else {
+            return nil
+        }
+    }
     
     var curation: Curation? {
         if case .curation(let curation) = self {
@@ -31,6 +41,14 @@ enum Item: Hashable {
         }
     }
     
+    var bookmarkedBookStore: Bookstore? {
+        if case .bookmarkedBookStore(let bookmarkedBookStore) = self {
+            return bookmarkedBookStore
+        } else {
+            return nil
+        }
+    }
+    
     var region: Region? {
         if case .region(let region) = self {
             return region
@@ -40,16 +58,16 @@ enum Item: Hashable {
     }
     
     // 같은 값이 들어가면 안됨(unique 해야함) -> 어떻게 구별? 다른 큐레이션 구조체(큐레이션 프로토콜 만들어도 괜찮으려나)를 만들어야하나 아니면 아이템의 케이스 하나 더 추가
-    static let mainCuration: [Item] = [
-        .curation(NewItems.mainDummy[0])
+    static var mainCuration: [Item] = [
+        .mainCuration(NewItems.curationDummy[Int.random(in: 0..<NewItems.curationDummy.count)])
     ]
     
-    static let curations: [Item] = NewItems.curationDummy.filter{ $0.id != "1" }.map{ .curation($0) }
+    static var curations: [Item] = NewItems.curationDummy.filter{ $0.id != "1" }.map{ .curation($0) }
     
     // MARK 추후 데이터 로직으로 filter와 sort를 이용해 거리순으로 제거 후 입력 받는다
-    static let nearByBookStores: [Item] = NewItems.bookstoreDummy.sorted{ $0.name > $1.name }.map{ .bookStore($0) }
+    static var nearByBookStores: [Item] = NewItems.bookstoreDummy.sorted{ $0.name > $1.name }.map{ .bookStore($0) }
     
-    static let bookmarkedBookStores: [Item] = NewItems.bookstoreDummy.filter{ $0.isFavorite }.map{ .bookStore($0) }
+    static var bookmarkedBookStores: [Item] = NewItems.bookstoreDummy.filter{ $0.isFavorite }.map{ .bookmarkedBookStore($0) }
     
     static let regions: [Item] = [
         .region(Region(name: "전체")),
@@ -62,4 +80,11 @@ enum Item: Hashable {
         .region(Region(name: "경남/울산/부산")),
         .region(Region(name: "제주"))
     ]
+    
+    static func updateBookmarkedData() {
+        bookmarkedBookStores = NewItems.bookstoreDummy.filter{ $0.isFavorite }.map{ .bookmarkedBookStore($0) }
+    }
+    
 }
+   
+    

--- a/Kindy/Kindy/Models/NewItems.swift
+++ b/Kindy/Kindy/Models/NewItems.swift
@@ -199,9 +199,6 @@ class NewItems {
                 break
             }
         }
-        print(NewItems.bookstoreDummy[index].isFavorite)
         NewItems.bookstoreDummy[index].isFavorite.toggle()
-        print(NewItems.bookstoreDummy[index].isFavorite)
-        print("success toggle")
     }
 }

--- a/Kindy/Kindy/View Controllers/DetailBookstoreViewController.swift
+++ b/Kindy/Kindy/View Controllers/DetailBookstoreViewController.swift
@@ -95,6 +95,7 @@ final class DetailBookstoreViewController: UIViewController {
         isBookmarked.toggle()
         isBookmarked ? bookmarkButton.setBackgroundImage(UIImage(systemName: "bookmark.fill"), for: .normal) : bookmarkButton.setBackgroundImage(UIImage(systemName: "bookmark"), for: .normal)
         navigationBarRightButton.image = isBookmarked ? UIImage(systemName: "bookmark.fill") : UIImage(systemName: "bookmark")
+        NewItems.bookmarkToggle(bookstore!)
     }
     
 }

--- a/Kindy/Kindy/View Controllers/HomeViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeViewController.swift
@@ -50,7 +50,6 @@ final class HomeViewController: UIViewController {
         } else {
             snapshot.appendSections([.bookmarked])
             snapshot.appendItems(Item.bookmarkedBookStores, toSection: .bookmarked)
-            print(Item.bookmarkedBookStores)
         }
         
         snapshot.appendSections([.region])

--- a/Kindy/Kindy/View Controllers/HomeViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeViewController.swift
@@ -41,7 +41,7 @@ final class HomeViewController: UIViewController {
             snapshot.appendItems([Item.emptyNearby], toSection: .emptyNearby)
         } else {
             snapshot.appendSections([.nearby])
-            snapshot.appendItems([Item.nearByBookStores[0], Item.nearByBookStores[1], Item.nearByBookStores[2]] , toSection: .nearby)
+            snapshot.appendItems([Item.nearByBookStores[0], Item.nearByBookStores[1], Item.nearByBookStores[2]], toSection: .nearby)
         }
         
         if Item.bookmarkedBookStores.isEmpty {
@@ -49,7 +49,8 @@ final class HomeViewController: UIViewController {
             snapshot.appendItems([Item.emptyBookmark], toSection: .emptyBookmark)
         } else {
             snapshot.appendSections([.bookmarked])
-            snapshot.appendItems(NewItems.bookstoreDummy.filter{ $0.isFavorite }.map{ .bookStore($0) }, toSection: .bookmarked)
+            snapshot.appendItems(Item.bookmarkedBookStores, toSection: .bookmarked)
+            print(Item.bookmarkedBookStores)
         }
         
         snapshot.appendSections([.region])
@@ -109,7 +110,7 @@ final class HomeViewController: UIViewController {
         // MARK: Tab Bar Appearance
         // 서점 상세화면으로 넘어갔다 오면 상세화면의 탭 바 설정이 적용되기에 재설정 해줬습니다.
         tabBarController?.tabBar.isHidden = false
-        
+        Item.updateBookmarkedData()
         dataSource.apply(snapshot)
     }
     
@@ -306,7 +307,7 @@ final class HomeViewController: UIViewController {
             switch section {
             case .mainCuration:
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MainCurationCollectionViewCell.identifier, for: indexPath) as? MainCurationCollectionViewCell else { return UICollectionViewCell() }
-                cell.configureCell(item.curation!)
+                cell.configureCell(item.mainCuration!)
 
                 return cell
             case .curation:
@@ -323,7 +324,7 @@ final class HomeViewController: UIViewController {
                 return cell
             case .bookmarked:
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BookmarkedCollectionViewCell.identifier, for: indexPath) as? BookmarkedCollectionViewCell else { return UICollectionViewCell() }
-                cell.configureCell(item.bookStore!)
+                cell.configureCell(item.bookmarkedBookStore!)
                 
                 return cell
             case .region:
@@ -422,7 +423,7 @@ extension HomeViewController: UICollectionViewDelegate {
         
         switch section {
         case .mainCuration:
-            let curation = Item.mainCuration.map { $0.curation! }.first!
+            let curation = Item.mainCuration.map { $0.mainCuration! }.first!
             let curationViewController = PagingCurationViewController(curation: curation)
             curationViewController.modalPresentationStyle = .overFullScreen
             curationViewController.modalTransitionStyle = .crossDissolve
@@ -442,7 +443,7 @@ extension HomeViewController: UICollectionViewDelegate {
             
             navigationController?.pushViewController(detailBookstoreViewController, animated: true)
         case .bookmarked:
-            let bookstore = NewItems.bookstoreDummy.filter{ $0.isFavorite }[indexPath.item]
+            let bookstore = Item.bookmarkedBookStores.map { $0.bookmarkedBookStore! }[indexPath.item]
             let detailBookstoreViewController = DetailBookstoreViewController()
             detailBookstoreViewController.bookstore = bookstore
             
@@ -471,9 +472,9 @@ extension HomeViewController: SectionHeaderDelegate {
             nearbyViewController.setupData(items: items)
             show(nearbyViewController, sender: nil)
         case 3:
-            let items = Item.bookmarkedBookStores.map { $0.bookStore! }
+            let items = Item.bookmarkedBookStores.map { $0.bookmarkedBookStore! }
             let bookmarkViewController = BookmarkViewController()
-            bookmarkViewController.setupData(items: NewItems.bookstoreDummy.filter{ $0.isFavorite })
+            bookmarkViewController.setupData(items: items)
             show(bookmarkViewController, sender: nil)
         default:
             return


### PR DESCRIPTION
# 배경
 - enum 구분 문제와, 데이터 호출시 데이터 업데이트가 반영이 되지 않았음, 그로 인해 뷰에 적용이 되지 않음
 - case 문제로 유니크한 값은 render하지 못함
# 작업 내용
## enum 자료 수정
 - curation, bookstore 의 case를 mainCuration, curation, bookstore, bookmarkedBookstore 로 나눔
 - 데이터 update 함수를 통해 호출 시 bookmarkedBookstore 데이터를 dummyData 상태와 싱크 맞춤
## HomeviewController
 - DiffableDatasource의 사용 데이터 값을 enum case 로 나누어서 적용시킴
 - viewWillAppear 함수 내부에 datasource.apply 전에 enum의 updateBookmarkedData함수를 호출하여 enum 데이터 변경
## DetailBookstoreViewController
 - 북마크 버튼에 dummyData내부에 isFavorite 값을 변경시켜지는 함수 추가

# 스크린샷
![simulator_screenshot_5B936B48-A0D9-4393-A7BA-CF120BD656F4](https://user-images.githubusercontent.com/31499563/198330721-804d52d8-4ffb-488a-9779-c5e10692ca64.png)



https://user-images.githubusercontent.com/31499563/198332643-0c140560-a012-402d-9dca-abe572254b7e.mp4


