### PR TITLE
네비게이션 바 UI를 구현했습니다.

### DIFF
--- a/Kindy/Kindy.xcodeproj/project.pbxproj
+++ b/Kindy/Kindy.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		77DCB16A29053B9900EAB5D5 /* HomeSearchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB16929053B9900EAB5D5 /* HomeSearchCell.swift */; };
 		77DCB1802909085F00EAB5D5 /* EmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB17F2909085F00EAB5D5 /* EmptyView.swift */; };
 		77DCB185290A5D9700EAB5D5 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCB184290A5D9700EAB5D5 /* UIView+.swift */; };
+		7B10E564290B8FEA009F543B /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B10E563290B8FEA009F543B /* UIImage+.swift */; };
 		7B404C1328FE889200A24C89 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B404C1228FE889200A24C89 /* UIColor+.swift */; };
 		7B404C1528FE88BD00A24C89 /* ResourcesFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B404C1428FE88BD00A24C89 /* ResourcesFile.swift */; };
 		7B404C1B28FE89BA00A24C89 /* Bookstore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B404C1A28FE89BA00A24C89 /* Bookstore.swift */; };
@@ -112,6 +113,7 @@
 		77DCB16929053B9900EAB5D5 /* HomeSearchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSearchCell.swift; sourceTree = "<group>"; };
 		77DCB17F2909085F00EAB5D5 /* EmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyView.swift; sourceTree = "<group>"; };
 		77DCB184290A5D9700EAB5D5 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
+		7B10E563290B8FEA009F543B /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		7B404C1228FE889200A24C89 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		7B404C1428FE88BD00A24C89 /* ResourcesFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourcesFile.swift; sourceTree = "<group>"; };
 		7B404C1A28FE89BA00A24C89 /* Bookstore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bookstore.swift; sourceTree = "<group>"; };
@@ -301,13 +303,14 @@
 		7B404C1028FE883900A24C89 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				7B404C1228FE889200A24C89 /* UIColor+.swift */,
 				6EE5E41F29027F5D00EA7413 /* NSObject+.swift */,
-				6EE5E4272905661E00EA7413 /* UIViewController+.swift */,
-				36BD7D63290404C200CBC879 /* UILabel+.swift */,
-				77DCB15129029CF500EAB5D5 /* UITableView+.swift */,
-				77DCB15329029D1F00EAB5D5 /* UIButton+.swift */,
 				77DCB184290A5D9700EAB5D5 /* UIView+.swift */,
+				36BD7D63290404C200CBC879 /* UILabel+.swift */,
+				77DCB15329029D1F00EAB5D5 /* UIButton+.swift */,
+				6EE5E4272905661E00EA7413 /* UIViewController+.swift */,
+				77DCB15129029CF500EAB5D5 /* UITableView+.swift */,
+				7B404C1228FE889200A24C89 /* UIColor+.swift */,
+				7B10E563290B8FEA009F543B /* UIImage+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -447,6 +450,7 @@
 				361D54CF2901CABB00ACA11E /* DetailBookstoreViewController.swift in Sources */,
 				6EE5E39F28FD313C00EA7413 /* HomeViewController.swift in Sources */,
 				31F7DD652904EB0C007E6E99 /* ImageCarouselCollectionViewCell.swift in Sources */,
+				7B10E564290B8FEA009F543B /* UIImage+.swift in Sources */,
 				7B404C2928FFD3B000A24C89 /* BookmarkedCollectionViewCell.swift in Sources */,
 				7B404C1528FE88BD00A24C89 /* ResourcesFile.swift in Sources */,
 				6EE5E4222902A8D300EA7413 /* CurationLayout.swift in Sources */,

--- a/Kindy/Kindy/Base.lproj/Main.storyboard
+++ b/Kindy/Kindy/Base.lproj/Main.storyboard
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Tiw-lN-1iE">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -18,7 +19,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="O9Q-w5-zgq">
-                                <rect key="frame" x="0.0" y="0.0" width="390" height="761"/>
+                                <rect key="frame" x="0.0" y="91" width="390" height="670"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="ISY-5c-MJP">
                                     <size key="itemSize" width="128" height="128"/>
@@ -33,7 +34,7 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="O9Q-w5-zgq" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="3ev-rB-QIE"/>
-                            <constraint firstItem="O9Q-w5-zgq" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="9EP-W6-sqh"/>
+                            <constraint firstItem="O9Q-w5-zgq" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="9EP-W6-sqh"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="O9Q-w5-zgq" secondAttribute="bottom" id="WHM-Pl-hqk"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="O9Q-w5-zgq" secondAttribute="trailing" id="mbl-A8-dCx"/>
                         </constraints>

--- a/Kindy/Kindy/Extensions/UIImage+.swift
+++ b/Kindy/Kindy/Extensions/UIImage+.swift
@@ -1,0 +1,22 @@
+//
+//  UIImage+.swift
+//  Kindy
+//
+//  Created by 정호윤 on 2022/10/28.
+//
+
+import UIKit
+
+extension UIImage {
+    
+    func resizeImage(size: CGSize) -> UIImage {
+        let originalSize = self.size
+        
+        let ratio: CGFloat = {
+            return originalSize.width > originalSize.height ? 1 / (size.width / originalSize.width) :
+            1 / (size.height / originalSize.height)
+        }()
+        
+        return UIImage(cgImage: self.cgImage!, scale: self.scale * ratio, orientation: self.imageOrientation)
+    }
+}

--- a/Kindy/Kindy/View Controllers/BookmarkViewController.swift
+++ b/Kindy/Kindy/View Controllers/BookmarkViewController.swift
@@ -44,6 +44,8 @@ final class BookmarkViewController: UIViewController {
         super.viewWillAppear(animated)
         self.tabBarController?.tabBar.isHidden = false
         
+        navigationController?.setNavigationBarHidden(false, animated: false)
+        
         // MARK: Navigation Bar Appearance
         // 서점 상세화면으로 넘어갔다 오면 상세화면의 네비게이션 바 설정이 적용되기에 재설정 해줬습니다.
         let customNavBarAppearance = UINavigationBarAppearance()

--- a/Kindy/Kindy/View Controllers/DetailBookstoreViewController.swift
+++ b/Kindy/Kindy/View Controllers/DetailBookstoreViewController.swift
@@ -54,6 +54,10 @@ final class DetailBookstoreViewController: UIViewController {
         setupDelegate()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        navigationController?.setNavigationBarHidden(false, animated: false)
+    }
+    
     override func viewDidAppear(_ animated: Bool) {
         setupBookstoreImages()
     }

--- a/Kindy/Kindy/View Controllers/HomeViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeViewController.swift
@@ -59,14 +59,15 @@ final class HomeViewController: UIViewController {
         
         return snapshot
     }
-
+    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         // MARK: Navigation Bar Button Item
-//        navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "KindyLogo"), style: .plain, target: nil, action: nil)
+        let scaledImage = UIImage(named: "KindyLogo")?.resizeImage(size: CGSize(width: 80, height: 20)).withRenderingMode(.alwaysOriginal)
+        navigationItem.leftBarButtonItem = UIBarButtonItem(image: scaledImage, style: .plain, target: nil, action: nil)
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .search, target: self, action: #selector(searchButtonTapped))
         navigationItem.rightBarButtonItem?.tintColor = UIColor(named: "kindyGreen")
         
@@ -95,7 +96,7 @@ final class HomeViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
+        
         // MARK: Navigation Bar Appearance
         // 서점 상세화면으로 넘어갔다 오면 상세화면의 네비게이션 바 설정이 적용되기에 재설정 해줬습니다.
         let customNavBarAppearance = UINavigationBarAppearance()
@@ -307,7 +308,7 @@ final class HomeViewController: UIViewController {
             case .mainCuration:
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MainCurationCollectionViewCell.identifier, for: indexPath) as? MainCurationCollectionViewCell else { return UICollectionViewCell() }
                 cell.configureCell(item.curation!)
-
+                
                 return cell
             case .curation:
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CurationCollectionViewCell.identifier, for: indexPath) as? CurationCollectionViewCell else { return UICollectionViewCell() }
@@ -479,4 +480,19 @@ extension HomeViewController: SectionHeaderDelegate {
             return
         }
     }
+}
+
+
+// MARK: Scroll View Delegate
+
+extension HomeViewController: UIScrollViewDelegate {
+    
+    func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        if (velocity.y > 0) {
+            navigationController?.setNavigationBarHidden(true, animated: true)
+        } else {
+            navigationController?.setNavigationBarHidden(false, animated: true)
+        }
+    }
+    
 }

--- a/Kindy/Kindy/View Controllers/NearbyViewController.swift
+++ b/Kindy/Kindy/View Controllers/NearbyViewController.swift
@@ -42,6 +42,8 @@ final class NearbyViewController: UIViewController, UISearchResultsUpdating {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        navigationController?.setNavigationBarHidden(false, animated: false)
+        
         // MARK: Navigation Bar Appearance
         // 서점 상세화면으로 넘어갔다 오면 상세화면의 네비게이션 바 설정이 적용되기에 재설정 해줬습니다.
         let customNavBarAppearance = UINavigationBarAppearance()

--- a/Kindy/Kindy/View Controllers/RegionViewController.swift
+++ b/Kindy/Kindy/View Controllers/RegionViewController.swift
@@ -41,6 +41,8 @@ final class RegionViewController: UIViewController, UISearchResultsUpdating {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        navigationController?.setNavigationBarHidden(false, animated: false)
+        
         // MARK: Navigation Bar Appearance
         // 서점 상세화면으로 넘어갔다 오면 상세화면의 네비게이션 바 설정이 적용되기에 재설정 해줬습니다.
         let customNavBarAppearance = UINavigationBarAppearance()


### PR DESCRIPTION
# 배경
네비게이션 바가 항상 떠있었고, 로고가 없었기 때문에 추가했습니다.

# 작업 내용
## 네비게이션 바 로고
- 네비게이션 바 left Item에 UImage 타입의 로고를 넣었습니다.
- ImageView가 아닌 UIImage를 넣다보니 렌더링이 이상하게돼 색이 까맣고, 크기와 위치가 마음대로인 문제가 있었습니다.
- UIImage의 extension으로 `resizeImage(size:)`라는 메서드를 추가해 이미지의 사이즈를 조절했습니다.
- `resizeImage(size:)`는 바꾸고 싶은 이미지의 사이즈를 입력받아 그에 맞게 바꿔주는 메서드입니다.
- 크기를 수정하고 렌더링 모드를 `withRenderingMode`메서드를 통해 `.alwaysOriginal`로 설정해 색문제도 해결했습니다.

## 네비게이션 바 애니메이션
- UIScrollViewDelegate를 활용해 아래로 내리면 네비게이션 바가 사라지고 위로 올리면 네비게이션 바가 나타나게 했습니다.
- 네비게이션바에 대한 설정이 다른 뷰컨들로 넘어가는 문제가 발생해 다른 뷰컨에서는 네비게이션 바가 보이도록 설정했습니다.

# 스크린샷
![Simulator Screen Shot - iPhone 14 - 2022-10-28 at 14 12 18](https://user-images.githubusercontent.com/65343417/198507961-498e5f69-ee67-4424-aec0-5b30e1e7cd51.png)

# 영상
https://user-images.githubusercontent.com/65343417/198507952-aac82cf3-61a2-414d-a309-14ffd39a3713.mp4


