### PR TITLE
🍿  피드백 내용과 컬러 폰트로 인해 코드를 수정하였습니다.

### DIFF
--- a/Kindy/Kindy/Extensions/UIView+.swift
+++ b/Kindy/Kindy/Extensions/UIView+.swift
@@ -18,3 +18,9 @@ extension UIView {
         }
     }
 }
+
+extension UIView {
+    var screenHeight: CGFloat {
+        return UIScreen.main.bounds.height
+    }
+}

--- a/Kindy/Kindy/Extensions/UIViewController+.swift
+++ b/Kindy/Kindy/Extensions/UIViewController+.swift
@@ -58,3 +58,9 @@ extension UIViewController: MFMailComposeViewControllerDelegate {
         present(sheet, animated: true)
     }
 }
+
+extension UIViewController {
+    var screenHeight: CGFloat {
+        return UIScreen.main.bounds.height
+    }
+}

--- a/Kindy/Kindy/View Controllers/Curation/BottomSheetViewController.swift
+++ b/Kindy/Kindy/View Controllers/Curation/BottomSheetViewController.swift
@@ -46,7 +46,7 @@ final class BottomSheetViewController: UIViewController {
     
     private lazy var bottomSheetPanStartingTopConstant: CGFloat = bottomSheetPanMinTopConstant
     
-    private var defaultHeight: CGFloat = UIScreen.main.bounds.height * 0.52
+    private lazy var defaultHeight: CGFloat = screenHeight * 0.52
     
     private let bottomSheetView: UIView = {
         let view = UIView()
@@ -91,9 +91,9 @@ final class BottomSheetViewController: UIViewController {
             bottomSheetPanStartingTopConstant = bottomSheetViewTopConstraint.constant
         case .changed:
             // 바텀 시트가 위에 고정 되어 있을때 드래그를 위로해도 아무런 일이 일어나지 않게 하는 코드
-            if bottomSheetPanStartingTopConstant == bottomSheetPanMinTopConstant && bottomSheetPanStartingTopConstant + translation.y > UIScreen.main.bounds.height * 0.65 { }
+            if bottomSheetPanStartingTopConstant == bottomSheetPanMinTopConstant && bottomSheetPanStartingTopConstant + translation.y > screenHeight * 0.65 { }
             // 바텀 시트 화면을 일정거리이상 밑으로 드래그 하는것을 방지
-            else if bottomSheetPanStartingTopConstant + translation.y > UIScreen.main.bounds.height * 0.65 && bottomSheetViewTopConstraint.constant != bottomSheetPanMinTopConstant {
+            else if bottomSheetPanStartingTopConstant + translation.y > screenHeight * 0.65 && bottomSheetViewTopConstraint.constant != bottomSheetPanMinTopConstant {
                 bottomSheetViewTopConstraint.constant = bottomSheetPanStartingTopConstant
                 
                 self.dismiss(animated: false)
@@ -113,7 +113,7 @@ final class BottomSheetViewController: UIViewController {
             let bottomPadding = view.safeAreaInsets.bottom
             let defaultPadding = safeAreaHeight+bottomPadding - defaultHeight
             
-            let standardHeight = UIScreen.main.bounds.height * 0.3
+            let standardHeight = screenHeight * 0.3
             
             let nearestValue = nearest(to: bottomSheetViewTopConstraint.constant, inValues: [bottomSheetPanMinTopConstant, standardHeight, defaultPadding, safeAreaHeight + bottomPadding])
           
@@ -166,7 +166,7 @@ final class BottomSheetViewController: UIViewController {
         
         bottomSheetViewTopConstraint = bottomSheetView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: topConstant)
         
-        let buttonConstant = UIScreen.main.bounds.height * 0.05
+        let buttonConstant = screenHeight * 0.05
         
         NSLayoutConstraint.activate([
             dismissButton.topAnchor.constraint(equalTo: view.topAnchor, constant: buttonConstant),

--- a/Kindy/Kindy/View Controllers/Curation/BottomSheetViewController.swift
+++ b/Kindy/Kindy/View Controllers/Curation/BottomSheetViewController.swift
@@ -42,7 +42,7 @@ final class BottomSheetViewController: UIViewController {
         return view
     }()
     
-    private var bottomSheetPanMinTopConstant: CGFloat = UIScreen.main.bounds.height * 0.13
+    private lazy var bottomSheetPanMinTopConstant: CGFloat = dismissButton.frame.height + 66.5
     
     private lazy var bottomSheetPanStartingTopConstant: CGFloat = bottomSheetPanMinTopConstant
     
@@ -166,9 +166,11 @@ final class BottomSheetViewController: UIViewController {
         
         bottomSheetViewTopConstraint = bottomSheetView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: topConstant)
         
+        let buttonConstant = UIScreen.main.bounds.height * 0.05
+        
         NSLayoutConstraint.activate([
-            dismissButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 50),
-            dismissButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -34),
+            dismissButton.topAnchor.constraint(equalTo: view.topAnchor, constant: buttonConstant),
+            dismissButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30),
             
             bottomSheetView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             bottomSheetView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),

--- a/Kindy/Kindy/View Controllers/Curation/PagingCurationViewController.swift
+++ b/Kindy/Kindy/View Controllers/Curation/PagingCurationViewController.swift
@@ -165,7 +165,9 @@ extension PagingCurationViewController: ChangeLayout {
     }
     
     func setTopHeaderLayout() {
-        headerViewHeightConstant = UIScreen.main.bounds.height * 0.36
+        let defaultHeight: CGFloat = (0.65 * UIScreen.main.bounds.height + 96.5) - (0.52 * UIScreen.main.bounds.height)
+                
+        headerViewHeightConstant = UIScreen.main.bounds.height * 0.05 + 30 + defaultHeight
         headerViewHeightConstraint.constant = headerViewHeightConstant
         UIView.animate(withDuration: 0.4, delay: 0, options: .curveEaseIn, animations: {
             self.view.layoutIfNeeded()

--- a/Kindy/Kindy/View Controllers/Curation/PagingCurationViewController.swift
+++ b/Kindy/Kindy/View Controllers/Curation/PagingCurationViewController.swift
@@ -113,7 +113,7 @@ class PagingCurationViewController: UIViewController {
         view.addSubview(headerView)
         view.addSubview(dimmingView)
         
-        headerViewHeightConstraint = headerView.heightAnchor.constraint(equalToConstant: UIScreen.main.bounds.height * 0.65)
+        headerViewHeightConstraint = headerView.heightAnchor.constraint(equalToConstant: screenHeight * 0.65)
         headerViewHeightConstant = headerViewHeightConstraint.constant
         headerViewDefaultHeightConstant = headerViewHeightConstraint.constant
         
@@ -165,9 +165,9 @@ extension PagingCurationViewController: ChangeLayout {
     }
     
     func setTopHeaderLayout() {
-        let defaultHeight: CGFloat = (0.65 * UIScreen.main.bounds.height + 96.5) - (0.52 * UIScreen.main.bounds.height)
+        let defaultHeight: CGFloat = (0.65 * screenHeight + 96.5) - (0.52 * screenHeight)
                 
-        headerViewHeightConstant = UIScreen.main.bounds.height * 0.05 + 30 + defaultHeight
+        headerViewHeightConstant = screenHeight * 0.05 + 30 + defaultHeight
         headerViewHeightConstraint.constant = headerViewHeightConstant
         UIView.animate(withDuration: 0.4, delay: 0, options: .curveEaseIn, animations: {
             self.view.layoutIfNeeded()

--- a/Kindy/Kindy/Views/Curation/CurationDetailCell.swift
+++ b/Kindy/Kindy/Views/Curation/CurationDetailCell.swift
@@ -33,7 +33,7 @@ final class CurationDetailCell: UICollectionViewCell {
     private lazy var descriptionLabel: UILabel = {
         let view = UILabel()
         view.textColor = .black
-        view.font = .systemFont(ofSize: 15)
+        view.font = .body2
         view.numberOfLines = 0
         view.textAlignment = .left
         view.adjustsFontSizeToFitWidth = true

--- a/Kindy/Kindy/Views/Curation/CurationHeaderView.swift
+++ b/Kindy/Kindy/Views/Curation/CurationHeaderView.swift
@@ -20,7 +20,7 @@ class CurationHeaderView: UIView {
     private lazy var titleLabel: UILabel = {
         let view = UILabel()
         view.textColor = .white
-        view.font = .systemFont(ofSize: 25, weight: .bold)
+        view.font = .title2
         view.numberOfLines = 2
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
@@ -29,7 +29,7 @@ class CurationHeaderView: UIView {
     private lazy var subtitleLabel: UILabel = {
         let view = UILabel()
         view.textColor = .white
-        view.font = .systemFont(ofSize: 17, weight: .light)
+        view.font = .title3
         view.numberOfLines = 2
         view.translatesAutoresizingMaskIntoConstraints = false
         return view

--- a/Kindy/Kindy/Views/Curation/CurationHeaderView.swift
+++ b/Kindy/Kindy/Views/Curation/CurationHeaderView.swift
@@ -50,13 +50,15 @@ class CurationHeaderView: UIView {
         self.addSubview(titleLabel)
         self.addSubview(subtitleLabel)
         
+        let defaultHeight: CGFloat = (0.65 * UIScreen.main.bounds.height + 96.5) - (0.52 * UIScreen.main.bounds.height)
+        
         NSLayoutConstraint.activate([
             imageView.topAnchor.constraint(equalTo: topAnchor),
             imageView.leadingAnchor.constraint(equalTo: leadingAnchor),
             imageView.bottomAnchor.constraint(equalTo: bottomAnchor),
             imageView.trailingAnchor.constraint(equalTo: trailingAnchor),
             
-            titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -200),
+            titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -defaultHeight),
             titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
             
             subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 14),

--- a/Kindy/Kindy/Views/Curation/CurationHeaderView.swift
+++ b/Kindy/Kindy/Views/Curation/CurationHeaderView.swift
@@ -50,7 +50,7 @@ class CurationHeaderView: UIView {
         self.addSubview(titleLabel)
         self.addSubview(subtitleLabel)
         
-        let defaultHeight: CGFloat = (0.65 * UIScreen.main.bounds.height + 96.5) - (0.52 * UIScreen.main.bounds.height)
+        let defaultHeight: CGFloat = (0.65 * screenHeight + 96.5) - (0.52 * screenHeight)
         
         NSLayoutConstraint.activate([
             imageView.topAnchor.constraint(equalTo: topAnchor),

--- a/Kindy/Kindy/Views/Curation/CurationStoreCell.swift
+++ b/Kindy/Kindy/Views/Curation/CurationStoreCell.swift
@@ -19,7 +19,7 @@ class CurationStoreCell: UICollectionViewCell {
     
     private lazy var lineView: UIView = {
         let view = UIView()
-        view.backgroundColor = .lightGray
+        view.backgroundColor = .kindyLightGray
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
@@ -37,7 +37,7 @@ class CurationStoreCell: UICollectionViewCell {
     private lazy var titleLabel: UILabel = {
         let view = UILabel()
         view.textColor = .black
-        view.font = .systemFont(ofSize: 17, weight: .bold)
+        view.font = .headline
         view.numberOfLines = 0
         view.textAlignment = .left
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -47,7 +47,7 @@ class CurationStoreCell: UICollectionViewCell {
     private lazy var descriptionLabel: UILabel = {
         let view = UILabel()
         view.textColor = .secondaryLabel
-        view.font = .systemFont(ofSize: 15)
+        view.font = .body2
         view.numberOfLines = 0
         view.textAlignment = .left
         view.translatesAutoresizingMaskIntoConstraints = false

--- a/Kindy/Kindy/Views/Curation/CurationTextCell.swift
+++ b/Kindy/Kindy/Views/Curation/CurationTextCell.swift
@@ -12,7 +12,7 @@ class CurationTextCell: UICollectionViewCell {
     private lazy var textLabel: UILabel = {
         let view = UILabel()
         view.textColor = .black
-        view.font = .systemFont(ofSize: 15)
+        view.font = .body2
         view.numberOfLines = 0
         view.textAlignment = .left
         view.adjustsFontSizeToFitWidth = true


### PR DESCRIPTION
# 배경

- 테스트 플라이트를 진행하며 받은 피드백을 적용해야 합니다.

# 작업 내용

- 버튼의 마진 값을 고정 값으로 주면 아이폰 SE의 경우 뷰가 혼자 너무 다른 느낌을 주어서 스크린 높이 * 0.05 로 마진 값을 주었습니다.
- 큐레이션 부제목과 바텀시트의 마진을 주기 위해 계산을 하여 오토레이아웃을 적용했습니다 (뷰 들이 다 제각각 다른 뷰 컨트롤러 내부에 있기 때문에 계산 하기 힘드러쓰 .. 좋은 방법이 있다면 알려주십쇼 ㅜㅡㅜ)
- 바텀 시트가 중앙에 있는 경우, 맨 위에 있는 경우를 나누어서 계산을 하였습니다.

# 스크린샷

<img src = "https://user-images.githubusercontent.com/66784492/199729746-86baefb9-a810-49ee-9d39-413ec6f741af.png" width = "40%" height = "40%"> <img src = "https://user-images.githubusercontent.com/66784492/199729833-ff626c23-6b43-4d76-9a15-129b5171440f.png" width = "40%" height = "40%">