### PR TITLE
🍿 홈 검색 화면, 내 주변 서점 목록, 지역별 서점 목록에 테스트 플라이트 피드백을 반영했습니다. 

### DIFF
--- a/Kindy/Kindy/Extensions/UIViewController+.swift
+++ b/Kindy/Kindy/Extensions/UIViewController+.swift
@@ -64,3 +64,14 @@ extension UIViewController {
         return UIScreen.main.bounds.height
     }
 }
+
+// MARK: - 서치바
+
+extension UIViewController {
+    func setupCustomCancelButton(of searchController: UISearchController) {
+        searchController.searchBar.setValue("취소", forKey: "cancelButtonText")
+        searchController.searchBar.tintColor = .black
+        searchController.searchBar.placeholder = "서점 이름, 주소 검색"
+        searchController.searchBar.setShowsCancelButton(true, animated: true)
+    }
+}

--- a/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
@@ -31,6 +31,7 @@ final class HomeSearchViewController: UIViewController, UISearchResultsUpdating 
         super.viewDidLoad()
 
         setupSearchController()
+        setupCustomCancelButton(of: searchController)
         setupTableView()
         
         dismissKeyboard()
@@ -68,15 +69,6 @@ final class HomeSearchViewController: UIViewController, UISearchResultsUpdating 
         searchController.searchResultsUpdater = self
         navigationItem.hidesSearchBarWhenScrolling = false
         searchController.obscuresBackgroundDuringPresentation = false
-        
-        customCancelButton()
-    }
-    
-    private func customCancelButton() {
-        searchController.searchBar.setValue("취소", forKey: "cancelButtonText")
-        searchController.searchBar.tintColor = UIColor(red: 0.173, green: 0.459, blue: 0.355, alpha: 1)
-        searchController.searchBar.placeholder = "서점 이름, 주소 검색"
-        searchController.searchBar.setShowsCancelButton(true, animated: true)
     }
     
     private func setupTableView() {

--- a/Kindy/Kindy/View Controllers/NearbyViewController.swift
+++ b/Kindy/Kindy/View Controllers/NearbyViewController.swift
@@ -42,6 +42,7 @@ final class NearbyViewController: UIViewController, UISearchResultsUpdating {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.navigationItem.title = "내 주변 서점"
         
         navigationController?.setNavigationBarHidden(false, animated: false)
         
@@ -50,6 +51,7 @@ final class NearbyViewController: UIViewController, UISearchResultsUpdating {
         let customNavBarAppearance = UINavigationBarAppearance()
         customNavBarAppearance.backgroundColor = .white
         
+        navigationController?.navigationBar.tintColor = .black
         navigationController?.navigationBar.standardAppearance = customNavBarAppearance
         navigationController?.navigationBar.scrollEdgeAppearance = customNavBarAppearance
         navigationController?.navigationBar.compactAppearance = customNavBarAppearance

--- a/Kindy/Kindy/View Controllers/NearbyViewController.swift
+++ b/Kindy/Kindy/View Controllers/NearbyViewController.swift
@@ -34,6 +34,7 @@ final class NearbyViewController: UIViewController, UISearchResultsUpdating {
         super.viewDidLoad()
         
         setupSearchController()
+        setupCustomCancelButton(of: searchController)
         setupTableView()
         
         dismissKeyboard()

--- a/Kindy/Kindy/View Controllers/RegionViewController.swift
+++ b/Kindy/Kindy/View Controllers/RegionViewController.swift
@@ -35,6 +35,7 @@ final class RegionViewController: UIViewController, UISearchResultsUpdating {
         super.viewDidLoad()
 
         setupSearchController()
+        setupCustomCancelButton(of: searchController)
         setupTableView()
 
         dismissKeyboard()

--- a/Kindy/Kindy/View Controllers/RegionViewController.swift
+++ b/Kindy/Kindy/View Controllers/RegionViewController.swift
@@ -43,6 +43,7 @@ final class RegionViewController: UIViewController, UISearchResultsUpdating {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.navigationItem.title = "지역별 서점"
         
         navigationController?.setNavigationBarHidden(false, animated: false)
         
@@ -51,6 +52,7 @@ final class RegionViewController: UIViewController, UISearchResultsUpdating {
         let customNavBarAppearance = UINavigationBarAppearance()
         customNavBarAppearance.backgroundColor = .white
         
+        navigationController?.navigationBar.tintColor = .black
         navigationController?.navigationBar.standardAppearance = customNavBarAppearance
         navigationController?.navigationBar.scrollEdgeAppearance = customNavBarAppearance
         navigationController?.navigationBar.compactAppearance = customNavBarAppearance

--- a/Kindy/Kindy/View Controllers/RegionViewController.swift
+++ b/Kindy/Kindy/View Controllers/RegionViewController.swift
@@ -21,7 +21,9 @@ final class RegionViewController: UIViewController, UISearchResultsUpdating {
         return view
     }()
 
-    private var filteredItems = Bookstore.dummyData
+    private var filteredItems = NewItems.bookstoreDummy
+    
+    private var regionItems: [Bookstore] = []
     
     private var regionName: String = ""
 
@@ -82,11 +84,11 @@ final class RegionViewController: UIViewController, UISearchResultsUpdating {
     // 서치바에 타이핑될 때 어떻게 할 건지 설정하는 함수 (유저의 검색에 반응하는 로직)
     func updateSearchResults(for searchController: UISearchController) {
         if let searchString = searchController.searchBar.text, searchString.isEmpty == false {
-            filteredItems = Bookstore.dummyData.filter{ (item) -> Bool in
+            filteredItems = regionItems.filter{ (item) -> Bool in
                 item.name.localizedCaseInsensitiveContains(searchString)
             }
         } else {
-            filteredItems = Bookstore.dummyData
+            filteredItems = regionItems
         }
 
         tableView.reloadData()
@@ -95,6 +97,7 @@ final class RegionViewController: UIViewController, UISearchResultsUpdating {
     func setupData(regionName: String) {
         self.regionName = regionName
         filteredItems = NewItems().getBookstoreByRegion(regionName)
+        regionItems = NewItems().getBookstoreByRegion(regionName)
     }
 }
 

--- a/Kindy/Kindy/Views/EmptyView/EmptyView.swift
+++ b/Kindy/Kindy/Views/EmptyView/EmptyView.swift
@@ -17,8 +17,7 @@ final class EmptyView: UIView {
     
     private let messageLabel: UILabel = {
         let label = UILabel()
-        label.textColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)
-        label.font = UIFont(name: "AppleSDGothicNeo-Regular", size: 15)
+        label.font = .body2
         label.textAlignment = .center
         label.sizeToFit()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -29,8 +28,8 @@ final class EmptyView: UIView {
     let reportButton: UIButton = {
         let btn = UIButton()
         btn.setTitle("독립서점 제보하기", for: .normal)
-        btn.setTitleColor(UIColor(red: 0.173, green: 0.459, blue: 0.355, alpha: 1), for: .normal)
-        btn.titleLabel?.font = UIFont(name: "AppleSDGothicNeo-Bold", size: 17)
+        btn.setTitleColor(.kindyPrimaryGreen, for: .normal)
+        btn.titleLabel?.font = .headline
         btn.translatesAutoresizingMaskIntoConstraints = false
         btn.setUnderline()
         

--- a/Kindy/Kindy/Views/HomeSearch/HomeSearchCell.swift
+++ b/Kindy/Kindy/Views/HomeSearch/HomeSearchCell.swift
@@ -24,7 +24,7 @@ final class HomeSearchCell: UITableViewCell {
         view.contentMode = .scaleAspectFill
         view.layer.cornerRadius = 8
         view.clipsToBounds = true      // radius를 imageView에 적용
-        view.backgroundColor = .lightGray
+        view.backgroundColor = .kindyLightGray
         view.translatesAutoresizingMaskIntoConstraints = false
         
         return view
@@ -32,7 +32,7 @@ final class HomeSearchCell: UITableViewCell {
     
     private var nameLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont(name: "AppleSDGothicNeo-Regular", size: 17)
+        label.font = .body1
         label.translatesAutoresizingMaskIntoConstraints = false
         
         return label

--- a/Kindy/Kindy/Views/Nearby/NearbyCell.swift
+++ b/Kindy/Kindy/Views/Nearby/NearbyCell.swift
@@ -33,7 +33,7 @@ final class NearbyCell: UITableViewCell {
         
         imageView.layer.cornerRadius = 8
         imageView.clipsToBounds = true      // radius를 imageView에 적용
-        imageView.backgroundColor = .lightGray      // 사진 없을 경우 default 색
+        imageView.backgroundColor = .kindyLightGray      // 사진 없을 경우 default 색
         
         return imageView
     }()
@@ -42,8 +42,7 @@ final class NearbyCell: UITableViewCell {
     private let nameLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont(name: "AppleSDGothicNeo-Bold", size: 17)
-        label.text = ""
+        label.font = .headline
 
         return label
     }()
@@ -52,8 +51,8 @@ final class NearbyCell: UITableViewCell {
     private let addressLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont(name: "AppleSDGothicNeo-Regular", size: 15)
-        label.textColor = UIColor(red: 0.459, green: 0.459, blue: 0.459, alpha: 1)
+        label.font = .body2
+        label.textColor = .kindyGray
         label.text = ""
         
         return label
@@ -63,8 +62,8 @@ final class NearbyCell: UITableViewCell {
     private let distanceLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont(name: "AppleSDGothicNeo-Regular", size: 17)
-        label.textColor = UIColor(red: 0.173, green: 0.459, blue: 0.355, alpha: 1)
+        label.font = .body1
+        label.textColor = .kindyPrimaryGreen
         label.text = ""
         
         return label

--- a/Kindy/Kindy/Views/Region/RegionCell.swift
+++ b/Kindy/Kindy/Views/Region/RegionCell.swift
@@ -23,7 +23,7 @@ final class RegionCell: UITableViewCell {
         view.contentMode = .scaleAspectFill
         view.layer.cornerRadius = 8
         view.clipsToBounds = true      // radius를 imageView에 적용
-        view.backgroundColor = .lightGray      // 사진 없을 경우 default 색
+        view.backgroundColor = .kindyLightGray      // 사진 없을 경우 default 색
         view.translatesAutoresizingMaskIntoConstraints = false
 
         return view
@@ -41,7 +41,7 @@ final class RegionCell: UITableViewCell {
 
     private let nameLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont(name: "AppleSDGothicNeo-Bold", size: 17)
+        label.font = .headline
         label.translatesAutoresizingMaskIntoConstraints = false
 
         return label
@@ -49,8 +49,8 @@ final class RegionCell: UITableViewCell {
 
     private let addressLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont(name: "AppleSDGothicNeo-Regular", size: 15)
-        label.textColor = UIColor(red: 0.459, green: 0.459, blue: 0.459, alpha: 1)
+        label.font = .body2
+        label.textColor = .kindyGray
         label.translatesAutoresizingMaskIntoConstraints = false
 
         return label

--- a/Kindy/Kindy/Views/Region/RegionHeaderView.swift
+++ b/Kindy/Kindy/Views/Region/RegionHeaderView.swift
@@ -10,11 +10,9 @@ final class RegionHeaderView: UITableViewHeaderFooterView {
 
     // MARK: - 프로퍼티
     
-
     var headerLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont(name: "AppleSDGothicNeo-Bold", size: 24)
-        label.textColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)
+        label.font = .title2
         label.translatesAutoresizingMaskIntoConstraints = false
 
         return label


### PR DESCRIPTION
# 배경
### 테스트 플라이트 피드백
- 테스트 플라이트에서 받은 피드백을 반영했습니다.

# 작업 내용
- 네비게이션 바 색깔을 모두 검정색으로 변경하였습니다.
- 서치바 placeholder 문구, 취소 버튼 문구를 통일했습니다.
- 그리고 공통으로 쓰이기 때문에 `Extensions/UIViewController+/` 파일에 검색 바의 취소 버튼 설정에 대한 코드를 정리했습니다.
- 지역별 서점에서 검색 바를 터치하면 다른 더미 데이터가 보여지는 에러를 수정했습니다.
- 각 `ViewController` 파일마다 `UISearchController` 에 대한 코드가 겹치는데, 다음 리팩토링때 모듈화를 시도해보겠습니다.

# 스크린샷

- 지역별 서점 검색 바 터치하면 다른 더미 데이터 나오는 이슈
- 코드에는 cancel 버튼 문구, 색상, 검색 창 placeholder 문구가 제대로 수정되어 있습니다.
- 이전 -> 이후
<table>
<tr>
<td><img src = "https://user-images.githubusercontent.com/77043329/200110177-ffaacca5-7320-4b64-bd38-b1d46e1116f2.png" width = "300"/></td>
<td><img src = "https://user-images.githubusercontent.com/77043329/200110180-885428ba-fd75-4fff-ad5f-2d3e20e42fc3.png" width = "300"/></td>
</tr>
</table>


