### PR TITLE
위치 권한 없을 때의 셀을 추가 + 리프레쉬 컨트롤 추가 + 유저를 이메일로 fetch 해오는 함수 구현했습니다.

### DIFF
--- a/Kindy/Kindy/Managers/FirestoreManager.swift
+++ b/Kindy/Kindy/Managers/FirestoreManager.swift
@@ -29,7 +29,7 @@ extension FirestoreManager {
     }
     
     // id로 큐레이션 fetch
-    func fetchCuration(with id: String) async throws -> Curation {
+    func fetchCuration(by id: String) async throws -> Curation {
         let curation = try await Reference.curations.document(id).getDocument(as: Curation.self)
         return curation
     }
@@ -51,7 +51,7 @@ extension FirestoreManager {
     }
     
     // id로 서점 fetch
-    func fetchBookstore(with id: String) async throws -> Bookstore {
+    func fetchBookstore(by id: String) async throws -> Bookstore {
         let bookstore = try await Reference.bookstores.document(id).getDocument(as: Bookstore.self)
         return bookstore
     }
@@ -70,6 +70,12 @@ extension FirestoreManager {
         let user = User(id: id, nickName: nickName, bookmarkedBookstores: [])
         try Reference.users.document(user.id).setData(from: user)
     }
+    
+    // 이메일로 유저 fetch
+    func fetchUser(by email: String) async throws -> User {
+        let user = try await Reference.users.document(email).getDocument(as: User.self)
+        return user
+    }
 }
 
 // MARK: - 이미지
@@ -80,7 +86,7 @@ extension FirestoreManager {
         case imageDataMissing
     }
     
-    func fetchImage(with url: String?) async throws -> UIImage {
+    func fetchImage(by url: String?) async throws -> UIImage {
         let (data, response) = try await URLSession.shared.data(from: URL(string: url ?? "")!)
         
         guard let httpResponse = response as? HTTPURLResponse,

--- a/Kindy/Kindy/Managers/FirestoreManager.swift
+++ b/Kindy/Kindy/Managers/FirestoreManager.swift
@@ -29,7 +29,7 @@ extension FirestoreManager {
     }
     
     // id로 큐레이션 fetch
-    func fetchCuration(by id: String) async throws -> Curation {
+    func fetchCuration(with id: String) async throws -> Curation {
         let curation = try await Reference.curations.document(id).getDocument(as: Curation.self)
         return curation
     }
@@ -51,7 +51,7 @@ extension FirestoreManager {
     }
     
     // id로 서점 fetch
-    func fetchBookstore(by id: String) async throws -> Bookstore {
+    func fetchBookstore(with id: String) async throws -> Bookstore {
         let bookstore = try await Reference.bookstores.document(id).getDocument(as: Bookstore.self)
         return bookstore
     }
@@ -66,13 +66,13 @@ extension FirestoreManager {
 
 extension FirestoreManager {
     // 유저 추가
-    func add(user id: String, nickName: String) throws {
-        let user = User(id: id, nickName: nickName, bookmarkedBookstores: [])
-        try Reference.users.document(user.id).setData(from: user)
+    func add(user email: String, nickName: String) throws {
+        let user = User(email: email, nickName: nickName, provider: "", bookmarkedBookstores: [])
+        try Reference.users.document(user.email).setData(from: user)
     }
     
     // 이메일로 유저 fetch
-    func fetchUser(by email: String) async throws -> User {
+    func fetchUser(with email: String) async throws -> User {
         let user = try await Reference.users.document(email).getDocument(as: User.self)
         return user
     }
@@ -86,7 +86,7 @@ extension FirestoreManager {
         case imageDataMissing
     }
     
-    func fetchImage(by url: String?) async throws -> UIImage {
+    func fetchImage(with url: String?) async throws -> UIImage {
         let (data, response) = try await URLSession.shared.data(from: URL(string: url ?? "")!)
         
         guard let httpResponse = response as? HTTPURLResponse,

--- a/Kindy/Kindy/Models/Home/ViewModel.swift
+++ b/Kindy/Kindy/Models/Home/ViewModel.swift
@@ -14,6 +14,7 @@ enum ViewModel {
         case nearbys
         case bookmarks
         case regions
+        case noPermission
     }
 
     enum Item: Hashable {
@@ -22,6 +23,7 @@ enum ViewModel {
         case nearByBookstore(Bookstore)
         case bookmarkedBookstore(Bookstore)
         case region(String)
+        case noPermission
         
         var curation: Curation? {
             if case .curation(let curation) = self {

--- a/Kindy/Kindy/Models/User.swift
+++ b/Kindy/Kindy/Models/User.swift
@@ -8,8 +8,9 @@
 import Foundation
 
 struct User {
-    let id: String
+    let email: String
     let nickName: String
+    let provider: String
     let bookmarkedBookstores: [String]
 }
 

--- a/Kindy/Kindy/Models/test.swift
+++ b/Kindy/Kindy/Models/test.swift
@@ -7,16 +7,16 @@
 
 import Foundation
 
-let curation = Curation(
-    userID: "",
-    bookstoreID: "82E1E431-19B9-4676-BAE2-79C95273D349",
-    title: "B급취향",
-    subTitle: "subtitle",
-    headText: "headText",
-    descriptions: [
-        Description(image: "https://firebasestorage.googleapis.com/v0/b/kindy-43d2d.appspot.com/o/Bookstores%2FB%EA%B8%89%EC%B7%A8%ED%96%A5%2FB%E1%84%80%E1%85%B3%E1%86%B8%E1%84%8E%E1%85%B1%E1%84%92%E1%85%A3%E1%86%BC1.jpeg?alt=media&token=f5fb5afa-c4f7-497e-b1ca-0aadebf82188", content: "content1"),
-        Description(image: "https://firebasestorage.googleapis.com/v0/b/kindy-43d2d.appspot.com/o/Bookstores%2FB%EA%B8%89%EC%B7%A8%ED%96%A5%2FB%E1%84%80%E1%85%B3%E1%86%B8%E1%84%8E%E1%85%B1%E1%84%92%E1%85%A3%E1%86%BC2.jpeg?alt=media&token=31e71556-ed46-48cb-86f4-28bcf9446936", content: "content2"),
-        Description(image: "https://firebasestorage.googleapis.com/v0/b/kindy-43d2d.appspot.com/o/Bookstores%2FB%EA%B8%89%EC%B7%A8%ED%96%A5%2FB%E1%84%80%E1%85%B3%E1%86%B8%E1%84%8E%E1%85%B1%E1%84%92%E1%85%A3%E1%86%BC4.jpeg?alt=media&token=15a27341-5f16-4a1b-b108-775fbb33ef55", content: "content3")
-    ],
-    likes: []
-)
+//let curation = Curation(
+//    userID: "",
+//    bookstoreID: "82E1E431-19B9-4676-BAE2-79C95273D349",
+//    title: "B급취향",
+//    subTitle: "subtitle",
+//    headText: "headText",
+//    descriptions: [
+//        Description(image: "https://firebasestorage.googleapis.com/v0/b/kindy-43d2d.appspot.com/o/Bookstores%2FB%EA%B8%89%EC%B7%A8%ED%96%A5%2FB%E1%84%80%E1%85%B3%E1%86%B8%E1%84%8E%E1%85%B1%E1%84%92%E1%85%A3%E1%86%BC1.jpeg?alt=media&token=f5fb5afa-c4f7-497e-b1ca-0aadebf82188", content: "content1"),
+//        Description(image: "https://firebasestorage.googleapis.com/v0/b/kindy-43d2d.appspot.com/o/Bookstores%2FB%EA%B8%89%EC%B7%A8%ED%96%A5%2FB%E1%84%80%E1%85%B3%E1%86%B8%E1%84%8E%E1%85%B1%E1%84%92%E1%85%A3%E1%86%BC2.jpeg?alt=media&token=31e71556-ed46-48cb-86f4-28bcf9446936", content: "content2"),
+//        Description(image: "https://firebasestorage.googleapis.com/v0/b/kindy-43d2d.appspot.com/o/Bookstores%2FB%EA%B8%89%EC%B7%A8%ED%96%A5%2FB%E1%84%80%E1%85%B3%E1%86%B8%E1%84%8E%E1%85%B1%E1%84%92%E1%85%A3%E1%86%BC4.jpeg?alt=media&token=15a27341-5f16-4a1b-b108-775fbb33ef55", content: "content3")
+//    ],
+//    likes: []
+//)

--- a/Kindy/Kindy/View Controllers/DetailBookstoreViewController.swift
+++ b/Kindy/Kindy/View Controllers/DetailBookstoreViewController.swift
@@ -10,82 +10,82 @@ import MapKit
 
 final class DetailBookstoreViewController: UIViewController {
     
-//    private var defaultScrollYOffset: CGFloat = 0
-//
-//    var bookstore: Bookstore?
-//
-//    let detailBookstoreView = DetailBookstoreView()
-//
-//    private lazy var mainScrollView = detailBookstoreView.mainScrollView
-//    private lazy var bookstoreImageScrollView = detailBookstoreView.bookstoreImageScrollView
+    private var defaultScrollYOffset: CGFloat = 0
+
+    var bookstore: Bookstore?
+
+    let detailBookstoreView = DetailBookstoreView()
+
+    private lazy var mainScrollView = detailBookstoreView.mainScrollView
+    private lazy var bookstoreImageScrollView = detailBookstoreView.bookstoreImageScrollView
 //    private lazy var bookstoreImages = detailBookstoreView.bookstoreImages
-//    private lazy var imagePageControl = detailBookstoreView.imagePageControl
-//
-//    private lazy var bookmarkButton = detailBookstoreView.bookmarkButton
-//    private lazy var isBookmarked = detailBookstoreView.isBookmarked
-//
-//    var navigationBarAppearance: UINavigationBarAppearance = {
-//        let navigationBarAppearance = UINavigationBarAppearance()
-//        // 네비게이션 바의 색을 수동으로 주기 위해 배경색, 그림자 제거
-//        navigationBarAppearance.configureWithTransparentBackground()
-//        return navigationBarAppearance
-//    }()
-//
-//    private lazy var navigationBarRightButton: UIBarButtonItem = {
-//        let button = UIBarButtonItem()
-//        button.image = isBookmarked ? UIImage(systemName: "bookmark.fill") : UIImage(systemName: "bookmark")
-//        button.style = .plain
-//        button.target = self
-//        button.action = #selector(bookmarkButtonTapped)
-//        return button
-//    }()
-//
-//    override func loadView() {
-//        view = detailBookstoreView
-//    }
-//
-//    // MARK: viewDidLoad()
-//    override func viewDidLoad() {
-//        super.viewDidLoad()
-//        setupBookstore()
-//        setupNavigationBar()
-//        setupTabbar()
-//        setupAddTarget()
-//        setupDelegate()
-//    }
-//
-//    override func viewWillAppear(_ animated: Bool) {
-//        navigationController?.setNavigationBarHidden(false, animated: false)
-//    }
-//
-//    override func viewDidAppear(_ animated: Bool) {
-//        setupBookstoreImages()
-//    }
-//
-//    private func setupBookstore() {
-//        detailBookstoreView.bookstore = bookstore
-//    }
-//
-//    private func setupNavigationBar() {
-//        navigationController?.navigationBar.tintColor = UIColor(named: "kindyGreen")
-//        navigationController?.navigationBar.topItem?.title = ""
-//    }
-//
-//    private func setupTabbar() {
-//        tabBarController?.tabBar.isHidden = true
-//    }
-//
-//    private func setupAddTarget() {
-//        bookmarkButton.addTarget(self, action: #selector(bookmarkButtonTapped), for: .touchUpInside)
-//    }
-//
-//    private func setupDelegate() {
-//        mainScrollView.delegate = self
-//        bookstoreImageScrollView.delegate = self
-//    }
-//
-//    // 서점 이미지 불러오기
-//    private func setupBookstoreImages() {
+    private lazy var imagePageControl = detailBookstoreView.imagePageControl
+
+    private lazy var bookmarkButton = detailBookstoreView.bookmarkButton
+    private lazy var isBookmarked = detailBookstoreView.isBookmarked
+
+    var navigationBarAppearance: UINavigationBarAppearance = {
+        let navigationBarAppearance = UINavigationBarAppearance()
+        // 네비게이션 바의 색을 수동으로 주기 위해 배경색, 그림자 제거
+        navigationBarAppearance.configureWithTransparentBackground()
+        return navigationBarAppearance
+    }()
+
+    private lazy var navigationBarRightButton: UIBarButtonItem = {
+        let button = UIBarButtonItem()
+        button.image = isBookmarked ? UIImage(systemName: "bookmark.fill") : UIImage(systemName: "bookmark")
+        button.style = .plain
+        button.target = self
+        button.action = #selector(bookmarkButtonTapped)
+        return button
+    }()
+
+    override func loadView() {
+        view = detailBookstoreView
+    }
+
+    // MARK: viewDidLoad()
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupBookstore()
+        setupNavigationBar()
+        setupTabbar()
+        setupAddTarget()
+        setupDelegate()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        navigationController?.setNavigationBarHidden(false, animated: false)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        setupBookstoreImages()
+    }
+
+    private func setupBookstore() {
+        detailBookstoreView.bookstore = bookstore
+    }
+
+    private func setupNavigationBar() {
+        navigationController?.navigationBar.tintColor = UIColor(named: "kindyGreen")
+        navigationController?.navigationBar.topItem?.title = ""
+    }
+
+    private func setupTabbar() {
+        tabBarController?.tabBar.isHidden = true
+    }
+
+    private func setupAddTarget() {
+        bookmarkButton.addTarget(self, action: #selector(bookmarkButtonTapped), for: .touchUpInside)
+    }
+
+    private func setupDelegate() {
+        mainScrollView.delegate = self
+        bookstoreImageScrollView.delegate = self
+    }
+
+    // 서점 이미지 불러오기
+    private func setupBookstoreImages() {
 //        for i in 0..<bookstoreImages.count {
 //            let imageView = UIImageView()
 //            imageView.frame = CGRect(x: view.frame.width * CGFloat(i), y: 0, width: bookstoreImageScrollView.frame.width, height: bookstoreImageScrollView.frame.height)
@@ -93,68 +93,68 @@ final class DetailBookstoreViewController: UIViewController {
 //            bookstoreImageScrollView.contentSize.width = imageView.frame.width * CGFloat(i + 1)
 //            bookstoreImageScrollView.addSubview(imageView)
 //        }
-//    }
-//
-//    @objc private func bookmarkButtonTapped() {
-//        isBookmarked.toggle()
-//        isBookmarked ? bookmarkButton.setBackgroundImage(UIImage(systemName: "bookmark.fill"), for: .normal) : bookmarkButton.setBackgroundImage(UIImage(systemName: "bookmark"), for: .normal)
-//        navigationBarRightButton.image = isBookmarked ? UIImage(systemName: "bookmark.fill") : UIImage(systemName: "bookmark")
+    }
+
+    @objc private func bookmarkButtonTapped() {
+        isBookmarked.toggle()
+        isBookmarked ? bookmarkButton.setBackgroundImage(UIImage(systemName: "bookmark.fill"), for: .normal) : bookmarkButton.setBackgroundImage(UIImage(systemName: "bookmark"), for: .normal)
+        navigationBarRightButton.image = isBookmarked ? UIImage(systemName: "bookmark.fill") : UIImage(systemName: "bookmark")
 //        NewItems.bookmarkToggle(bookstore!)
-//    }
+    }
     
 }
 
-//extension DetailBookstoreViewController: UIScrollViewDelegate {
-//    
-//    // 이미지 스크롤 했을때
-//    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-//        switch scrollView {
-//        // 스크롤이 메인스크롤이라면 네비게이션바 수정
-//        case mainScrollView:
-//            let currentScrollYOffset = scrollView.contentOffset.y
-//            
-//            // 밑으로 내릴수록 네비게이션 바의 배경색을 하얗게 변경
-//            if currentScrollYOffset > defaultScrollYOffset {
-//                navigationBarAppearance.backgroundColor = .init(white: currentScrollYOffset / 175, alpha: currentScrollYOffset / 175)
-//                navigationBarAppearance.shadowColor = .init(red: 0, green: 0, blue: 0, alpha: ((currentScrollYOffset / 175) * 0.3))
-//            // 상단 화면을 보고 있으면 네비게이션 바 안보이게 변경
-//            } else {
-//                navigationBarAppearance.backgroundColor = .clear
-//                navigationBarAppearance.shadowColor = .clear
-//            }
-//            setNavigationBarAppearance()
-//            
-//            // 서점 이름을 가리는 순간 서점 이름과 북마크 버튼 네비게이션 바에 표시
-//            if currentScrollYOffset >= 230 {
-//                guard let bookstore = bookstore else { return }
-//                navigationController?.navigationBar.topItem?.title = "\(bookstore.name)"
-//                navigationItem.rightBarButtonItem = navigationBarRightButton
-//            } else {
-//                navigationController?.navigationBar.topItem?.title = ""
-//                navigationItem.rightBarButtonItem = nil
-//            }
-//            
-//        // 스크롤이 서점 이미지 스크롤이라면 현재 페이지 변경
-//        case bookstoreImageScrollView:
-//            let currentValue = scrollView.contentOffset.x / scrollView.frame.size.width
-//            setupPageControlSelectedPage(currentPage: Int(round(currentValue)))
-//            
-//        default:
-//            print("ScrollView Error!")
-//            break
-//        }
-//    }
-//    
-//    // 네비게이션 바 모습 변경
-//    private func setNavigationBarAppearance() {
-//        navigationController?.navigationBar.standardAppearance = navigationBarAppearance
-//        navigationController?.navigationBar.compactAppearance = navigationBarAppearance
-//        navigationController?.navigationBar.scrollEdgeAppearance = navigationBarAppearance
-//    }
-//    
-//    // 현재 이미지의 페이지에 따라 pageControl의 currentPage 변경
-//    private func setupPageControlSelectedPage(currentPage: Int) {
-//        imagePageControl.currentPage = currentPage
-//    }
-//    
-//}
+extension DetailBookstoreViewController: UIScrollViewDelegate {
+
+    // 이미지 스크롤 했을때
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        switch scrollView {
+        // 스크롤이 메인스크롤이라면 네비게이션바 수정
+        case mainScrollView:
+            let currentScrollYOffset = scrollView.contentOffset.y
+
+            // 밑으로 내릴수록 네비게이션 바의 배경색을 하얗게 변경
+            if currentScrollYOffset > defaultScrollYOffset {
+                navigationBarAppearance.backgroundColor = .init(white: currentScrollYOffset / 175, alpha: currentScrollYOffset / 175)
+                navigationBarAppearance.shadowColor = .init(red: 0, green: 0, blue: 0, alpha: ((currentScrollYOffset / 175) * 0.3))
+            // 상단 화면을 보고 있으면 네비게이션 바 안보이게 변경
+            } else {
+                navigationBarAppearance.backgroundColor = .clear
+                navigationBarAppearance.shadowColor = .clear
+            }
+            setNavigationBarAppearance()
+
+            // 서점 이름을 가리는 순간 서점 이름과 북마크 버튼 네비게이션 바에 표시
+            if currentScrollYOffset >= 230 {
+                guard let bookstore = bookstore else { return }
+                navigationController?.navigationBar.topItem?.title = "\(bookstore.name)"
+                navigationItem.rightBarButtonItem = navigationBarRightButton
+            } else {
+                navigationController?.navigationBar.topItem?.title = ""
+                navigationItem.rightBarButtonItem = nil
+            }
+
+        // 스크롤이 서점 이미지 스크롤이라면 현재 페이지 변경
+        case bookstoreImageScrollView:
+            let currentValue = scrollView.contentOffset.x / scrollView.frame.size.width
+            setupPageControlSelectedPage(currentPage: Int(round(currentValue)))
+
+        default:
+            print("ScrollView Error!")
+            break
+        }
+    }
+
+    // 네비게이션 바 모습 변경
+    private func setNavigationBarAppearance() {
+        navigationController?.navigationBar.standardAppearance = navigationBarAppearance
+        navigationController?.navigationBar.compactAppearance = navigationBarAppearance
+        navigationController?.navigationBar.scrollEdgeAppearance = navigationBarAppearance
+    }
+
+    // 현재 이미지의 페이지에 따라 pageControl의 currentPage 변경
+    private func setupPageControlSelectedPage(currentPage: Int) {
+        imagePageControl.currentPage = currentPage
+    }
+
+}

--- a/Kindy/Kindy/View Controllers/HomeViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeViewController.swift
@@ -439,7 +439,7 @@ final class HomeViewController: UIViewController {
             
             guard let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: SupplementaryViewKind.header, withReuseIdentifier: SectionHeaderView.identifier, for: indexPath) as? SectionHeaderView else { return UICollectionReusableView() }
             
-            //                headerView.delegate = self
+            headerView.delegate = self
             
             switch kind {
             case SupplementaryViewKind.header:
@@ -507,30 +507,30 @@ extension HomeViewController: UICollectionViewDelegate {
             curationViewController.modalTransitionStyle = .crossDissolve
             
             present(curationViewController, animated: true)
-            //        case .bookstores:
-            //            let bookstore = model.bookstores.map { $0.bookstore! }
-            //            let detailBookstoreViewController = DetailBookstoreViewController()
-            //            detailBookstoreViewController.bookstore = bookstore
-            //
-            //            navigationController?.pushViewController(detailBookstoreViewController, animated: true)
-            //        case .nearbys:
-            //            let bookstore = model.bookstores.map { $0.bookstore! }
-            //            let detailBookstoreViewController = DetailBookstoreViewController()
-            //            detailBookstoreViewController.bookstore = bookstore
-            //
-            //            navigationController?.pushViewController(detailBookstoreViewController, animated: true)
-            //        case .bookmarks:
-            //
-            //            let detailBookstoreViewController = DetailBookstoreViewController()
-            //            detailBookstoreViewController.bookstore = bookstore
-            //
-            //            navigationController?.pushViewController(detailBookstoreViewController, animated: true)
-            //        case .regions:
-            //            let regionName = model.regions[indexPath.item]
-            //            let regionViewController = RegionViewController()
-            //            regionViewController.setupData(regionName: regionName)
-            //
-            //            show(regionViewController, sender: nil)
+        case .bookstores:
+            let bookstore = model.bookstores.map { $0.bookstore! }[indexPath.item]
+            let detailBookstoreViewController = DetailBookstoreViewController()
+            detailBookstoreViewController.bookstore = bookstore
+            
+            navigationController?.pushViewController(detailBookstoreViewController, animated: true)
+        case .nearbys:
+            let bookstore = model.bookstores.map { $0.bookstore! }[indexPath.item]
+            let detailBookstoreViewController = DetailBookstoreViewController()
+            detailBookstoreViewController.bookstore = bookstore
+            
+            navigationController?.pushViewController(detailBookstoreViewController, animated: true)
+//        case .bookmarks:
+//
+//            let detailBookstoreViewController = DetailBookstoreViewController()
+//            detailBookstoreViewController.bookstore = bookstore
+//
+//            navigationController?.pushViewController(detailBookstoreViewController, animated: true)
+        case .regions:
+            let model = model.regions[indexPath.item]
+            let regionViewController = RegionViewController()
+            regionViewController.setupData(regionName: model.region!)
+            
+            show(regionViewController, sender: nil)
         default:
             return
         }
@@ -539,26 +539,25 @@ extension HomeViewController: UICollectionViewDelegate {
 
 // MARK: - Section Header Delegate
 
-// TODO: 0번째 섹션 추가해야함
-//extension HomeViewController: SectionHeaderDelegate {
-//
-//    func segueWithSectionIndex(_ sectionIndex: Int) {
-//        switch sectionIndex {
-//        case 2:
-//            let items = Item.nearByBookStores.map { $0.bookstore! }
-//            let nearbyViewController = NearbyViewController()
-//            nearbyViewController.setupData(items: items)
-//            show(nearbyViewController, sender: nil)
+extension HomeViewController: SectionHeaderDelegate {
+
+    func segueWithSectionIndex(_ sectionIndex: Int) {
+        switch sectionIndex {
+        case 2:
+            let nearbyBookstores = model.bookstores.map { $0.bookstore! }
+            let nearbyViewController = NearbyViewController()
+            nearbyViewController.setupData(items: nearbyBookstores)
+            show(nearbyViewController, sender: nil)
 //        case 3:
 //            let items = Item.bookmarkedBookStores.map { $0.bookstore! }
 //            let bookmarkViewController = BookmarkViewController()
 //            bookmarkViewController.setupData(items: items)
 //            show(bookmarkViewController, sender: nil)
-//        default:
-//            return
-//        }
-//    }
-//}
+        default:
+            return
+        }
+    }
+}
 
 
 // MARK: - Scroll View Delegate
@@ -585,10 +584,10 @@ extension HomeViewController: CLLocationManagerDelegate {
         var sortedBookstores = bookstores
         
         for i in 0..<bookstores.count {
-            sortedBookstores[i].distance = Int(myLocation.distance(from: CLLocationCoordinate2D(latitude: sortedBookstores[i].location.latitude, longitude: sortedBookstores[i].location.longitude)))
+            sortedBookstores[i].distance = Int(myLocation.distance(from: CLLocationCoordinate2D(latitude: sortedBookstores[i].location.latitude, longitude: sortedBookstores[i].location.longitude))) / 1000
         }
         // TODO: 거리 범위 조절, 거리에 따라 m, km 조정 로직 구현 필요
-        sortedBookstores = sortedBookstores.filter { $0.distance < 200000 }.sorted { $0.distance < $1.distance }
+        sortedBookstores = sortedBookstores.filter { $0.distance < 500 }.sorted { $0.distance < $1.distance }
         
         return sortedBookstores
     }

--- a/Kindy/Kindy/View Controllers/HomeViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeViewController.swift
@@ -13,9 +13,9 @@ import FirebaseFirestoreSwift
 final class HomeViewController: UIViewController {
     
     // MARK: Tasks
-    var bookstoresRequestTask: Task<Void, Never>?
-    var curationsRequestTask: Task<Void, Never>?
-    var imageRequestTask: Task<Void, Never>?
+    private var bookstoresRequestTask: Task<Void, Never>?
+    private var curationsRequestTask: Task<Void, Never>?
+    private var imageRequestTask: Task<Void, Never>?
     
     deinit {
         bookstoresRequestTask?.cancel()
@@ -24,10 +24,10 @@ final class HomeViewController: UIViewController {
     }
     
     // MARK: Managers
-    let firestoreManager = FirestoreManager()
-    let locationManager = CLLocationManager()
+    private let firestoreManager = FirestoreManager()
+    private let locationManager = CLLocationManager()
     
-    var model = Model()
+    private var model = Model()
     
     enum SupplementaryViewKind {
         static let header = "header"
@@ -39,7 +39,7 @@ final class HomeViewController: UIViewController {
     
     private var dataSource: UICollectionViewDiffableDataSource<ViewModel.Section, ViewModel.Item>!
     
-    var snapshot: NSDiffableDataSourceSnapshot<ViewModel.Section, ViewModel.Item> {
+    private var snapshot: NSDiffableDataSourceSnapshot<ViewModel.Section, ViewModel.Item> {
         var snapshot = NSDiffableDataSourceSnapshot<ViewModel.Section, ViewModel.Item>()
         
         snapshot.appendSections([.curations])

--- a/Kindy/Kindy/View Controllers/HomeViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeViewController.swift
@@ -398,7 +398,7 @@ final class HomeViewController: UIViewController {
                 cell.configureCell(item.curation!)
                 
                 self.imageRequestTask = Task {
-                    if let image = try? await firestoreManager.fetchImage(by: item.curation?.descriptions[indexPath.item].image) {
+                    if let image = try? await firestoreManager.fetchImage(with: item.curation?.descriptions[indexPath.item].image) {
                         cell.imageView.image = image
                     }
                     imageRequestTask = nil
@@ -412,7 +412,7 @@ final class HomeViewController: UIViewController {
                 cell.configureCell(item.bookstore!, indexPath: indexPath, numberOfItems: numberOfItems)
                 
                 self.imageRequestTask = Task {
-                    if let image = try? await firestoreManager.fetchImage(by: item.bookstore?.images?.first!) {
+                    if let image = try? await firestoreManager.fetchImage(with: item.bookstore?.images?.first!) {
                         cell.imageView.image = image
                     }
                     imageRequestTask = nil
@@ -424,7 +424,7 @@ final class HomeViewController: UIViewController {
                 cell.configureCell(item.bookstore!)
                 
                 self.imageRequestTask = Task {
-                    if let image = try? await firestoreManager.fetchImage(by: item.bookstore?.images?[0]) {
+                    if let image = try? await firestoreManager.fetchImage(with: item.bookstore?.images?[0]) {
                         cell.imageView.image = image
                     }
                     imageRequestTask = nil

--- a/Kindy/Kindy/View Controllers/HomeViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeViewController.swift
@@ -1,8 +1,8 @@
 //
-//  ViewController.swift
+//  HomeViewController.swift
 //  Kindy
 //
-//  Created by rbwo on 2022/10/17.
+//  Created by 정호윤 on 2022/10/17.
 //
 
 import UIKit

--- a/Kindy/Kindy/View Controllers/HomeViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeViewController.swift
@@ -12,7 +12,7 @@ import FirebaseFirestoreSwift
 
 final class HomeViewController: UIViewController {
     
-    // MARK: Task
+    // MARK: Tasks
     var bookstoresRequestTask: Task<Void, Never>?
     var curationsRequestTask: Task<Void, Never>?
     var imageRequestTask: Task<Void, Never>?
@@ -23,6 +23,7 @@ final class HomeViewController: UIViewController {
         imageRequestTask?.cancel()
     }
     
+    // MARK: Managers
     let firestoreManager = FirestoreManager()
     let locationManager = CLLocationManager()
     
@@ -62,23 +63,21 @@ final class HomeViewController: UIViewController {
         return snapshot
     }
     
-    // MARK: - Life Cycle
+    // MARK: - Life Cycles
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        createBarButtonItems()
+        createNavBarButtonItems()
         
-        // MARK: Configure Layout
+        // MARK: Configuration
         collectionView.collectionViewLayout = createLayout()
-        
-        // MARK: Configure Data Source
         configureDataSource()
         
         // MARK: Delegate
         collectionView.delegate = self
         
-        // MARK: Registeration
+        // MARK: Registerations
         // Cell Registeration
         collectionView.register(CurationCollectionViewCell.self, forCellWithReuseIdentifier: CurationCollectionViewCell.identifier)
         collectionView.register(BookstoreCollectionViewCell.self, forCellWithReuseIdentifier: BookstoreCollectionViewCell.identifier)
@@ -122,7 +121,7 @@ final class HomeViewController: UIViewController {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         
-        // TODO: Task cancellation
+        // MARK: Task cancellation
         curationsRequestTask?.cancel()
         bookstoresRequestTask?.cancel()
         imageRequestTask?.cancel()
@@ -130,7 +129,7 @@ final class HomeViewController: UIViewController {
     
     // MARK:  - Navigation Bar
     
-    func createBarButtonItems() {
+    func createNavBarButtonItems() {
         let scaledImage = UIImage(named: "KindyLogo")?.resizeImage(size: CGSize(width: 80, height: 20)).withRenderingMode(.alwaysOriginal)
         navigationItem.leftBarButtonItem = UIBarButtonItem(image: scaledImage, style: .plain, target: nil, action: nil)
         
@@ -144,13 +143,13 @@ final class HomeViewController: UIViewController {
         navigationItem.rightBarButtonItems = [searchButton]
     }
     
-    // 네비게이션 바의 검색 버튼이 눌렸을때 실행되는 함수입니다.
+    // 네비게이션 바의 검색 버튼이 눌렸을때 실행되는 함수
     @objc func searchButtonTapped() {
         let homeSearchViewController = HomeSearchViewController()
         show(homeSearchViewController, sender: nil)
     }
     
-    // 네비게이션 바의 종 버튼이 눌렸을때 실행되는 함수입니다.
+    // 네비게이션 바의 종 버튼이 눌렸을때 실행되는 함수
     @objc func bellButtonTapped() {
         
     }
@@ -158,7 +157,6 @@ final class HomeViewController: UIViewController {
     // MARK: - Update
     
     func update() {
-        // TODO: Task들이 너무 많아지면 어떡하나
         curationsRequestTask?.cancel()
         curationsRequestTask = Task {
             if let curations = try? await firestoreManager.fetchCurations() {
@@ -479,12 +477,7 @@ final class HomeViewController: UIViewController {
                     hideBottomStackView = true
                 }
                 
-                headerView.configure(
-                    title: sectionName,
-                    hideSeeAllButton: hideSeeAllButton,
-                    hideBottomStackView: hideBottomStackView,
-                    sectionIndex: indexPath.section
-                )
+                headerView.configure(title: sectionName, hideSeeAllButton: hideSeeAllButton, hideBottomStackView: hideBottomStackView, sectionIndex: indexPath.section)
                 
                 return headerView
             default:

--- a/Kindy/Kindy/View Controllers/HomeViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeViewController.swift
@@ -73,6 +73,7 @@ final class HomeViewController: UIViewController {
         // MARK: Configuration
         collectionView.collectionViewLayout = createLayout()
         configureDataSource()
+        configureRefreshControl()
         
         // MARK: Delegate
         collectionView.delegate = self
@@ -152,6 +153,21 @@ final class HomeViewController: UIViewController {
     // 네비게이션 바의 종 버튼이 눌렸을때 실행되는 함수
     @objc func bellButtonTapped() {
         
+    }
+    
+    // MARK: - Refresh Control
+    
+    func configureRefreshControl() {
+        collectionView.refreshControl = UIRefreshControl()
+        collectionView.refreshControl?.addTarget(self, action: #selector(handleRefreshControl), for: .valueChanged)
+    }
+    
+    @objc func handleRefreshControl() {
+        update()
+        
+        DispatchQueue.main.async {
+            self.collectionView.refreshControl?.endRefreshing()
+        }
     }
     
     // MARK: - Update

--- a/Kindy/Kindy/View Controllers/HomeViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeViewController.swift
@@ -52,7 +52,7 @@ final class HomeViewController: UIViewController {
         case .notDetermined, .denied, .restricted:
             snapshot.appendSections([.noPermission])
             snapshot.appendItems([ViewModel.Item.noPermission])
-        @unknown default:
+        default:
             snapshot.appendSections([.nearbys])
             snapshot.appendItems(model.bookstores)
         }
@@ -398,7 +398,7 @@ final class HomeViewController: UIViewController {
                 cell.configureCell(item.curation!)
                 
                 self.imageRequestTask = Task {
-                    if let image = try? await firestoreManager.fetchImage(with: item.curation?.descriptions[indexPath.item].image) {
+                    if let image = try? await firestoreManager.fetchImage(by: item.curation?.descriptions[indexPath.item].image) {
                         cell.imageView.image = image
                     }
                     imageRequestTask = nil
@@ -412,7 +412,7 @@ final class HomeViewController: UIViewController {
                 cell.configureCell(item.bookstore!, indexPath: indexPath, numberOfItems: numberOfItems)
                 
                 self.imageRequestTask = Task {
-                    if let image = try? await firestoreManager.fetchImage(with: item.bookstore?.images?.first!) {
+                    if let image = try? await firestoreManager.fetchImage(by: item.bookstore?.images?.first!) {
                         cell.imageView.image = image
                     }
                     imageRequestTask = nil
@@ -424,7 +424,7 @@ final class HomeViewController: UIViewController {
                 cell.configureCell(item.bookstore!)
                 
                 self.imageRequestTask = Task {
-                    if let image = try? await firestoreManager.fetchImage(with: item.bookstore?.images?[0]) {
+                    if let image = try? await firestoreManager.fetchImage(by: item.bookstore?.images?[0]) {
                         cell.imageView.image = image
                     }
                     imageRequestTask = nil

--- a/Kindy/Kindy/Views/Detail/DetailBookstoreView.swift
+++ b/Kindy/Kindy/Views/Detail/DetailBookstoreView.swift
@@ -8,452 +8,453 @@
 import UIKit
 import MapKit
 
+// FIXME: 주석처리한 부분과 기타 디테일을 수정해주세용
 final class DetailBookstoreView: UIView {
-//
-//    private let padding16: CGFloat = 16
-//    private let padding24: CGFloat = 24
-//
-//    var bookstore: Bookstore? {
-//        didSet {
-//            guard let bookstore = self.bookstore else { return }
-//            if let bookstoreImages = bookstore.images {
+
+    private let padding16: CGFloat = 16
+    private let padding24: CGFloat = 24
+
+    var bookstore: Bookstore? {
+        didSet {
+            guard let bookstore = self.bookstore else { return }
+            if let bookstoreImages = bookstore.images {
 //                self.bookstoreImages = bookstoreImages
-//                imagePageControl.numberOfPages = bookstoreImages.count
-//            }
-//            nameLabel.text = bookstore.name
-//            shortAddressLabel.text = bookstore.shortAddress
+                imagePageControl.numberOfPages = bookstoreImages.count
+            }
+            nameLabel.text = bookstore.name
+            shortAddressLabel.text = bookstore.shortAddress
 //            isBookmarked = bookstore.isFavorite
-//            isBookmarked ? bookmarkButton.setBackgroundImage(UIImage(systemName: "bookmark.fill"), for: .normal) : bookmarkButton.setBackgroundImage(UIImage(systemName: "bookmark"), for: .normal)
-//            telephoneNumberLabel.text = bookstore.telNumber
-//            let optionalInstagramID = bookstore.instagramURL?.components(separatedBy: "/")[3]
-//            guard let instagramID = optionalInstagramID else { return }
-//            instagramButton.setTitle("@\(instagramID)", for: .normal)
-//            instagramButton.setUnderline()
-//            businessHourLabel.text = """
-//            월 \(bookstore.businessHour.monday)
-//            화 \(bookstore.businessHour.tuesday)
-//            수 \(bookstore.businessHour.wednesday)
-//            목 \(bookstore.businessHour.thursday)
-//            금 \(bookstore.businessHour.friday)
-//            토 \(bookstore.businessHour.saturday)
-//            일 \(bookstore.businessHour.sunday)
-//            """
-//            descriptionLabel.text = bookstore.description
-//            address.text = bookstore.address
-//            bookstoreCoordinate = CLLocationCoordinate2D(latitude: bookstore.location.latitude, longitude: bookstore.location.longitude)
-//            bookstorePin.title = bookstore.name
-//            bookstorePin.coordinate = CLLocationCoordinate2D(latitude: bookstore.location.latitude, longitude: bookstore.location.longitude)
-//            setupMapView()
-//        }
-//    }
-//
-//    // 서점 데이터 기본값
-//    // 서점 사진이 없을 경우 보여줄 사진도 필요
+            isBookmarked ? bookmarkButton.setBackgroundImage(UIImage(systemName: "bookmark.fill"), for: .normal) : bookmarkButton.setBackgroundImage(UIImage(systemName: "bookmark"), for: .normal)
+            telephoneNumberLabel.text = bookstore.contact.telNumber
+            let optionalInstagramID = bookstore.contact.instagramURL?.components(separatedBy: "/")[3]
+            guard let instagramID = optionalInstagramID else { return }
+            instagramButton.setTitle("@\(instagramID)", for: .normal)
+            instagramButton.setUnderline()
+            businessHourLabel.text = """
+            \(bookstore.businessHour.monday ?? "nil")
+            \(bookstore.businessHour.tuesday ?? "nil")
+            \(bookstore.businessHour.wednesday ?? "nil")
+            \(bookstore.businessHour.thursday ?? "nil")
+            \(bookstore.businessHour.friday ?? "nil")
+            \(bookstore.businessHour.saturday ?? "nil")
+            \(bookstore.businessHour.sunday ?? "nil")
+            """
+            descriptionLabel.text = bookstore.description
+            address.text = bookstore.address
+            bookstoreCoordinate = CLLocationCoordinate2D(latitude: bookstore.location.latitude, longitude: bookstore.location.longitude)
+            bookstorePin.title = bookstore.name
+            bookstorePin.coordinate = CLLocationCoordinate2D(latitude: bookstore.location.latitude, longitude: bookstore.location.longitude)
+            setupMapView()
+        }
+    }
+
+    // 서점 데이터 기본값
+    // 서점 사진이 없을 경우 보여줄 사진도 필요
 //    var bookstoreImages: [UIImage] = [UIImage(named: "testImage")!]
-//    var isBookmarked: Bool = false
-//    private var bookstoreCoordinate = CLLocationCoordinate2D(latitude: 36.0090456, longitude: 129.3331438)
-//
-//    // 전체 화면을 덮는 스크롤뷰
-//    let mainScrollView: UIScrollView = {
-//        let scrollView = UIScrollView()
-//        scrollView.showsVerticalScrollIndicator = false
-//        scrollView.translatesAutoresizingMaskIntoConstraints = false
-//        return scrollView
-//    }()
-//
-//    // 서점 이미지 페이징에서 사용할 스크롤뷰
-//    let bookstoreImageScrollView: UIScrollView = {
-//        let scrollView = UIScrollView()
-//        scrollView.showsVerticalScrollIndicator = false
-//        scrollView.showsHorizontalScrollIndicator = false
-//        scrollView.isPagingEnabled = true
-//        scrollView.translatesAutoresizingMaskIntoConstraints = false
-//        return scrollView
-//    }()
-//
-//    // 서점 이미지 페이지 컨트롤
-//    lazy var imagePageControl: UIPageControl = {
-//        let pageControl = UIPageControl()
-//        pageControl.translatesAutoresizingMaskIntoConstraints = false
-//        return pageControl
-//    }()
-//
-//    // 서점 이름 레이블
-//    let nameLabel: UILabel = {
-//        let label = UILabel()
-//        label.text = "달팽이책방"
-//        label.font = UIFont.systemFont(ofSize: 24, weight: .bold)
-//        label.translatesAutoresizingMaskIntoConstraints = false
-//        return label
-//    }()
-//
-//    lazy var bookmarkButton: UIButton = {
-//        let button = UIButton()
-//        isBookmarked ? button.setBackgroundImage(UIImage(systemName: "bookmark.fill"), for: .normal) : button.setBackgroundImage(UIImage(systemName: "bookmark"), for: .normal)
-//        button.tintColor = UIColor(named: "kindyGreen")
-//        button.translatesAutoresizingMaskIntoConstraints = false
-//        return button
-//    }()
-//
-//    // 서점 이름과 북마크 버튼을 묶는 스택뷰
-//    private lazy var nameStackView: UIStackView = {
-//        let stackView = UIStackView(arrangedSubviews: [nameLabel, bookmarkButton])
-//        stackView.axis = .horizontal
-//        stackView.spacing = 20
-//        stackView.alignment = .center
-//        stackView.distribution = .fill
-//        stackView.translatesAutoresizingMaskIntoConstraints = false
-//        return stackView
-//    }()
-//
-//    // 서점의 짧은 주소 레이블
-//    private let shortAddressLabel: UILabel = {
-//        let label = UILabel()
-//        label.text = "경상북도 포항시 남구"
-//        label.font = UIFont.systemFont(ofSize: 17)
-//        label.textColor = UIColor(named: "kindyGray")
-//        label.translatesAutoresizingMaskIntoConstraints = false
-//        return label
-//    }()
-//
-//    private lazy var headerStackView: UIStackView = {
-//        let stackView = UIStackView(arrangedSubviews: [nameStackView, shortAddressLabel])
-//        stackView.axis = .vertical
-//        stackView.spacing = 0
-//        stackView.distribution = .fill
-//        stackView.translatesAutoresizingMaskIntoConstraints = false
-//        return stackView
-//    }()
-//
-//    // 서점 이름과 요약 정보 사이의 디바이더
-//    private let topDivider: UIView = {
-//        let view = UIView()
-//        view.backgroundColor = UIColor(named: "kindyLightGray")
-//        view.translatesAutoresizingMaskIntoConstraints = false
-//        return view
-//    }()
-//
-//    // 전화기 아이콘
-//    private let telephoneIconImageView: UIImageView = {
-//        let imageView = UIImageView()
-//        imageView.image = UIImage(systemName: "phone")
-//        imageView.contentMode = .center
-//        imageView.tintColor = UIColor(named: "kindyGray")
-//        imageView.translatesAutoresizingMaskIntoConstraints = false
-//        return imageView
-//    }()
-//
-//    // 전화번호 레이블
-//    private let telephoneNumberLabel: UILabel = {
-//        let label = UILabel()
-//        label.text = "054-782-7653"
-//        label.font = UIFont.systemFont(ofSize: 15)
-//        label.translatesAutoresizingMaskIntoConstraints = false
-//        return label
-//    }()
-//
-//    // 전화 스택뷰
-//    private lazy var telephoneStackView: UIStackView = {
-//        let stackView = UIStackView(arrangedSubviews: [telephoneIconImageView, telephoneNumberLabel])
-//        stackView.axis = .horizontal
-//        stackView.distribution = .fill
-//        stackView.alignment = .center
-//        stackView.spacing = 8
-//        stackView.translatesAutoresizingMaskIntoConstraints = false
-//        return stackView
-//    }()
-//
-//    // TODO: 인스타그램 없을시 숨기기 구현
-//    // 인스타그램 아이콘
-//    private let instagrameIconImageView: UIImageView = {
-//        let imageView = UIImageView()
-//        imageView.image = UIImage(named: "instagramIcon")
-//        imageView.tintColor = UIColor(named: "kindyGray")
-//        imageView.translatesAutoresizingMaskIntoConstraints = false
-//        return imageView
-//    }()
-//
-//    // 인스타그램 주소 버튼
-//    private lazy var instagramButton: UIButton = {
-//        let button = UIButton()
-////        button.setTitle("https://www.instagram.com/bookshopsnail/", for: .normal)
-//        button.setTitleColor(.black, for: .normal)
-//        button.titleLabel?.font = UIFont.systemFont(ofSize: 15)
-//        button.contentHorizontalAlignment = .left
-//        button.setUnderline()
-//        button.addTarget(self, action: #selector(instagramButtonTapped), for: .touchUpInside)
-//        button.translatesAutoresizingMaskIntoConstraints = false
-//        return button
-//    }()
-//
-//    // 인스타그램 스택뷰
-//    private lazy var instagramStackView: UIStackView = {
-//        let stackView = UIStackView(arrangedSubviews: [instagrameIconImageView, instagramButton])
-//        stackView.axis = .horizontal
-//        stackView.distribution = .fill
-//        stackView.alignment = .center
-//        stackView.spacing = 8
-//        stackView.translatesAutoresizingMaskIntoConstraints = false
-//        return stackView
-//    }()
-//
-//    // 운영시간 아이콘
-//    private let businessHourIconImageView: UIImageView = {
-//        let imageView = UIImageView()
-//        imageView.image = UIImage(systemName: "clock")
-//        imageView.contentMode = .center
-//        imageView.tintColor = UIColor(named: "kindyGray")
-//        imageView.translatesAutoresizingMaskIntoConstraints = false
-//        return imageView
-//    }()
-//
-//    // 운영시간 레이블
-//    private let businessHourLabel: UILabel = {
-//        let label = UILabel()
-//        label.text = """
-//        월, 화, 수 9:00 - 20:00
-//        목, 금 9:00 - 20:00
-//        토,일 9:00 - 20:00
-//        """
-//        label.numberOfLines = 0
-//        label.font = UIFont.systemFont(ofSize: 15)
-//        label.setLineSpacing(lineSpacing: 8) // 라인 간격 조절
-//        label.translatesAutoresizingMaskIntoConstraints = false
-//        return label
-//    }()
-//
-//    // 운영시간 스택뷰
-//    private lazy var businessHourStackView: UIStackView = {
-//        let stackView = UIStackView(arrangedSubviews: [businessHourIconImageView, businessHourLabel])
-//        stackView.axis = .horizontal
-//        stackView.distribution = .fill
-//        stackView.alignment = .top
-//        stackView.spacing = 8
-//        stackView.translatesAutoresizingMaskIntoConstraints = false
-//        return stackView
-//    }()
-//
-//    // 서점의 기본 정보를 담고있는 스택뷰
-//    private lazy var infoSummaryStackView: UIStackView = {
-//        let stackView = UIStackView(arrangedSubviews: [telephoneStackView, instagramStackView, businessHourStackView])
-//        stackView.axis = .vertical
-//        stackView.spacing = 8
-//        stackView.translatesAutoresizingMaskIntoConstraints = false
-//        return stackView
-//    }()
-//
-//    // 서점의 기본 정보와 탑 디바이더를 담고있는 스택뷰
-//    private lazy var summaryStackView: UIStackView = {
-//        let stackView = UIStackView(arrangedSubviews: [topDivider, infoSummaryStackView])
-//        stackView.axis = .vertical
-//        stackView.spacing = padding24
-//        stackView.distribution = .fill
-//        stackView.translatesAutoresizingMaskIntoConstraints = false
-//        return stackView
-//    }()
-//
-//    // 요약 정보와 서점 설명 사이의 디바이더
-//    private let middleDivider: UIView = {
-//        let view = UIView()
-//        view.backgroundColor = UIColor(named: "kindyLightGray")
-//        view.translatesAutoresizingMaskIntoConstraints = false
-//        return view
-//    }()
-//
-//    // 서점 상세설명 레이블
-//    private let descriptionLabel: UILabel = {
-//        let label = UILabel()
-//        label.text = "Happiness is good health and a bad memory.Time moves in one direction, memory in another. History is not a burden on the memory but an illumination of the soul. Happiness is good health and a bad memory. Time moves in one direction, memory in another. History is not a burden on the memory but an illumination of the soul. History is not a burden on the memory but an illumination of the soul."
-//        label.font = UIFont.systemFont(ofSize: 17)
-//        label.numberOfLines = 0
-//        label.setLineSpacing(lineSpacing: 6)
-//        label.translatesAutoresizingMaskIntoConstraints = false
-//        return label
-//    }()
-//
-//    // 서점 상세설명과 미들 디바이더를 담고 있는 스택뷰
-//    private lazy var descriptionStackView: UIStackView = {
-//        let stackView = UIStackView(arrangedSubviews: [middleDivider, descriptionLabel])
-//        stackView.axis = .vertical
-//        stackView.spacing = padding24
-//        stackView.distribution = .fill
-//        stackView.translatesAutoresizingMaskIntoConstraints = false
-//        return stackView
-//    }()
-//
-//    // 서점 설명과 맵 뷰 사이의 디바이더
-//    private let bottomDivider: UIView = {
-//        let view = UIView()
-//        view.backgroundColor = UIColor(named: "kindyLightGray")
-//        view.translatesAutoresizingMaskIntoConstraints = false
-//        return view
-//    }()
-//
-//    // 지도 아이콘 이미지 뷰
-//    private let mapIconImageView: UIImageView = {
-//        let imageView = UIImageView()
-//        imageView.image = UIImage(systemName: "map")
-//        imageView.contentMode = .center
-//        imageView.tintColor = UIColor(named: "kindyGray")
-//        imageView.translatesAutoresizingMaskIntoConstraints = false
-//        return imageView
-//    }()
-//
-//    // 하단 서점 상세 주소 레이블
-//    private let address: UILabel = {
-//        let label = UILabel()
-//        label.text = "경상북도 포항시 남구 효자동길10번길 32"
-//        label.font = UIFont.systemFont(ofSize: 15)
-//        label.translatesAutoresizingMaskIntoConstraints = false
-//        return label
-//    }()
-//
-//    private lazy var addressStackView: UIStackView = {
-//        let stackView = UIStackView(arrangedSubviews: [mapIconImageView, address])
-//        stackView.axis = .horizontal
-//        stackView.spacing = 8
-//        stackView.translatesAutoresizingMaskIntoConstraints = false
-//        return stackView
-//    }()
-//
-//    private let bookstoreMapView: MKMapView = {
-//        let mapView = MKMapView()
-//        mapView.layer.masksToBounds = true
-//        mapView.layer.cornerRadius = 8
-//        mapView.translatesAutoresizingMaskIntoConstraints = false
-//        return mapView
-//    }()
-//
-//    private lazy var bookstorePin: MKPointAnnotation = {
-//        let pin = MKPointAnnotation()
-//        guard let bookstoreName = nameLabel.text else { return pin }
-//        pin.title = bookstoreName
-//        pin.coordinate = bookstoreCoordinate
-//        return pin
-//    }()
-//
-//    private lazy var bookstoreMapStackView: UIStackView = {
-//        let stackView = UIStackView(arrangedSubviews: [bottomDivider, addressStackView, bookstoreMapView])
-//        stackView.axis = .vertical
-//        stackView.spacing = 24
-//        stackView.distribution = .fill
-//        stackView.translatesAutoresizingMaskIntoConstraints = false
-//        return stackView
-//    }()
-//
-//    // MARK: init
-//    override init(frame: CGRect) {
-//        super.init(frame: frame)
-//        backgroundColor = .white
-//        setupUI()
-//        setupMapView()
-//    }
-//
-//    required init?(coder: NSCoder) {
-//        fatalError("init(coder:) has not been implemented")
-//    }
-//
-//    private func setupUI() {
-//        addSubview(mainScrollView)
-//        bookstoreImageScrollView.backgroundColor = .lightGray
-//
-//        mainScrollView.addSubview(bookstoreImageScrollView)
-//        mainScrollView.addSubview(imagePageControl)
-//        mainScrollView.addSubview(headerStackView)
-//        mainScrollView.addSubview(summaryStackView)
-//        mainScrollView.addSubview(descriptionStackView)
-//        mainScrollView.addSubview(bookstoreMapStackView)
-//
-//        // 고정값 UI들 설정
-//        setupDividerConstraints()
-//        setupIconConstraints()
-//
-//        NSLayoutConstraint.activate([
-//            // 메인 스크롤뷰 설정
-//            mainScrollView.topAnchor.constraint(equalTo: topAnchor),
-//            mainScrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
-//            mainScrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
-//            mainScrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
-//
-//            // 서점 이미지뷰 설정
-//            bookstoreImageScrollView.topAnchor.constraint(equalTo: mainScrollView.topAnchor, constant: -100),
-//            bookstoreImageScrollView.leadingAnchor.constraint(equalTo: mainScrollView.leadingAnchor),
-//            bookstoreImageScrollView.trailingAnchor.constraint(equalTo: mainScrollView.trailingAnchor),
-//            bookstoreImageScrollView.heightAnchor.constraint(equalToConstant: 368),
-//
-//            imagePageControl.topAnchor.constraint(equalTo: bookstoreImageScrollView.bottomAnchor, constant: -padding24),
-//            imagePageControl.leadingAnchor.constraint(equalTo: mainScrollView.leadingAnchor),
-//            imagePageControl.trailingAnchor.constraint(equalTo: mainScrollView.trailingAnchor),
-//            imagePageControl.bottomAnchor.constraint(equalTo: bookstoreImageScrollView.bottomAnchor, constant: -padding16),
-//
-//            // 서점 이름, 짧은 주소, 북마크 버튼뷰
-//            nameStackView.heightAnchor.constraint(equalToConstant: 36),
-//            shortAddressLabel.heightAnchor.constraint(equalToConstant: 25),
-//            headerStackView.topAnchor.constraint(equalTo: bookstoreImageScrollView.bottomAnchor, constant: padding24),
-//            headerStackView.leadingAnchor.constraint(equalTo: mainScrollView.leadingAnchor, constant: padding16),
-//            headerStackView.trailingAnchor.constraint(equalTo: mainScrollView.trailingAnchor, constant: -padding16),
-//
-//            // 탑 디바이더와 서점 기본 정보뷰
-//            summaryStackView.topAnchor.constraint(equalTo: headerStackView.bottomAnchor, constant: padding24),
-//            summaryStackView.leadingAnchor.constraint(equalTo: mainScrollView.leadingAnchor, constant: padding16),
-//            summaryStackView.trailingAnchor.constraint(equalTo: mainScrollView.trailingAnchor, constant: -padding16),
-//
-//            // 미들 디바이더와 서점 상세 정보뷰
-//            descriptionStackView.topAnchor.constraint(equalTo: summaryStackView.bottomAnchor, constant: padding24),
-//            descriptionStackView.leadingAnchor.constraint(equalTo: mainScrollView.leadingAnchor, constant: padding16),
-//            descriptionStackView.trailingAnchor.constraint(equalTo: mainScrollView.trailingAnchor, constant: -padding16),
-//
-//            // 바텀 디바이더와 서점 지도뷰
-//            bookstoreMapView.heightAnchor.constraint(equalToConstant: UIScreen.main.bounds.height * 0.36),
-//            bookstoreMapStackView.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor, constant: padding24),
-//            bookstoreMapStackView.leadingAnchor.constraint(equalTo: mainScrollView.leadingAnchor, constant: padding16),
-//            bookstoreMapStackView.trailingAnchor.constraint(equalTo: mainScrollView.trailingAnchor, constant: -padding16),
-//            bookstoreMapStackView.bottomAnchor.constraint(equalTo: mainScrollView.bottomAnchor, constant: -100)
-//        ])
-//    }
-//
-//    private func setupDividerConstraints() {
-//        NSLayoutConstraint.activate([
-//            topDivider.widthAnchor.constraint(equalToConstant: UIScreen.main.bounds.width - (padding16 * 2)),
-//            topDivider.heightAnchor.constraint(equalToConstant: 1),
-//
-//            middleDivider.widthAnchor.constraint(equalToConstant: UIScreen.main.bounds.width - (padding16 * 2)),
-//            middleDivider.heightAnchor.constraint(equalToConstant: 1),
-//
-//            bottomDivider.widthAnchor.constraint(equalToConstant: UIScreen.main.bounds.width - (padding16 * 2)),
-//            bottomDivider.heightAnchor.constraint(equalToConstant: 1),
-//        ])
-//    }
-//
-//    private func setupIconConstraints() {
-//        NSLayoutConstraint.activate([
-//            bookmarkButton.heightAnchor.constraint(equalToConstant: 36),
-//            bookmarkButton.widthAnchor.constraint(equalToConstant: 32),
-//
-//            telephoneIconImageView.widthAnchor.constraint(equalToConstant: 22),
-//            telephoneIconImageView.heightAnchor.constraint(equalToConstant: 22),
-//
-//            instagrameIconImageView.widthAnchor.constraint(equalToConstant: 22),
-//            instagrameIconImageView.heightAnchor.constraint(equalToConstant: 22),
-//
-//            businessHourIconImageView.widthAnchor.constraint(equalToConstant: 22),
-//            businessHourIconImageView.heightAnchor.constraint(equalToConstant: 22),
-//
-//            mapIconImageView.widthAnchor.constraint(equalToConstant: 22),
-//            mapIconImageView.widthAnchor.constraint(equalToConstant: 22),
-//        ])
-//    }
-//
-//    private func setupMapView() {
-//        bookstoreMapView.setRegion(MKCoordinateRegion(center: bookstoreCoordinate, span: MKCoordinateSpan(latitudeDelta: 0.005, longitudeDelta: 0.005)), animated: true)
-//        bookstoreMapView.addAnnotation(bookstorePin)
-//    }
-//
-//    @objc private func instagramButtonTapped() {
-//
-//        guard let instagramAddress = bookstore?.instagramURL else { return }
-//        guard let url = URL(string: instagramAddress) else { return }
-//        UIApplication.shared.open(url, options: [:])
-//    }
+    var isBookmarked: Bool = false
+    private var bookstoreCoordinate = CLLocationCoordinate2D(latitude: 36.0090456, longitude: 129.3331438)
+
+    // 전체 화면을 덮는 스크롤뷰
+    let mainScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        return scrollView
+    }()
+
+    // 서점 이미지 페이징에서 사용할 스크롤뷰
+    let bookstoreImageScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.isPagingEnabled = true
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        return scrollView
+    }()
+
+    // 서점 이미지 페이지 컨트롤
+    lazy var imagePageControl: UIPageControl = {
+        let pageControl = UIPageControl()
+        pageControl.translatesAutoresizingMaskIntoConstraints = false
+        return pageControl
+    }()
+
+    // 서점 이름 레이블
+    let nameLabel: UILabel = {
+        let label = UILabel()
+        label.text = "달팽이책방"
+        label.font = UIFont.systemFont(ofSize: 24, weight: .bold)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    lazy var bookmarkButton: UIButton = {
+        let button = UIButton()
+        isBookmarked ? button.setBackgroundImage(UIImage(systemName: "bookmark.fill"), for: .normal) : button.setBackgroundImage(UIImage(systemName: "bookmark"), for: .normal)
+        button.tintColor = UIColor(named: "kindyGreen")
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    // 서점 이름과 북마크 버튼을 묶는 스택뷰
+    private lazy var nameStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [nameLabel, bookmarkButton])
+        stackView.axis = .horizontal
+        stackView.spacing = 20
+        stackView.alignment = .center
+        stackView.distribution = .fill
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    // 서점의 짧은 주소 레이블
+    private let shortAddressLabel: UILabel = {
+        let label = UILabel()
+        label.text = "경상북도 포항시 남구"
+        label.font = UIFont.systemFont(ofSize: 17)
+        label.textColor = UIColor(named: "kindyGray")
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private lazy var headerStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [nameStackView, shortAddressLabel])
+        stackView.axis = .vertical
+        stackView.spacing = 0
+        stackView.distribution = .fill
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    // 서점 이름과 요약 정보 사이의 디바이더
+    private let topDivider: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(named: "kindyLightGray")
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    // 전화기 아이콘
+    private let telephoneIconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "phone")
+        imageView.contentMode = .center
+        imageView.tintColor = UIColor(named: "kindyGray")
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    // 전화번호 레이블
+    private let telephoneNumberLabel: UILabel = {
+        let label = UILabel()
+        label.text = "054-782-7653"
+        label.font = UIFont.systemFont(ofSize: 15)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    // 전화 스택뷰
+    private lazy var telephoneStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [telephoneIconImageView, telephoneNumberLabel])
+        stackView.axis = .horizontal
+        stackView.distribution = .fill
+        stackView.alignment = .center
+        stackView.spacing = 8
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    // TODO: 인스타그램 없을시 숨기기 구현
+    // 인스타그램 아이콘
+    private let instagrameIconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "instagramIcon")
+        imageView.tintColor = UIColor(named: "kindyGray")
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    // 인스타그램 주소 버튼
+    private lazy var instagramButton: UIButton = {
+        let button = UIButton()
+//        button.setTitle("https://www.instagram.com/bookshopsnail/", for: .normal)
+        button.setTitleColor(.black, for: .normal)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 15)
+        button.contentHorizontalAlignment = .left
+        button.setUnderline()
+        button.addTarget(self, action: #selector(instagramButtonTapped), for: .touchUpInside)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    // 인스타그램 스택뷰
+    private lazy var instagramStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [instagrameIconImageView, instagramButton])
+        stackView.axis = .horizontal
+        stackView.distribution = .fill
+        stackView.alignment = .center
+        stackView.spacing = 8
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    // 운영시간 아이콘
+    private let businessHourIconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "clock")
+        imageView.contentMode = .center
+        imageView.tintColor = UIColor(named: "kindyGray")
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    // 운영시간 레이블
+    private let businessHourLabel: UILabel = {
+        let label = UILabel()
+        label.text = """
+        월, 화, 수 9:00 - 20:00
+        목, 금 9:00 - 20:00
+        토,일 9:00 - 20:00
+        """
+        label.numberOfLines = 0
+        label.font = UIFont.systemFont(ofSize: 15)
+        label.setLineSpacing(lineSpacing: 8) // 라인 간격 조절
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    // 운영시간 스택뷰
+    private lazy var businessHourStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [businessHourIconImageView, businessHourLabel])
+        stackView.axis = .horizontal
+        stackView.distribution = .fill
+        stackView.alignment = .top
+        stackView.spacing = 8
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    // 서점의 기본 정보를 담고있는 스택뷰
+    private lazy var infoSummaryStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [telephoneStackView, instagramStackView, businessHourStackView])
+        stackView.axis = .vertical
+        stackView.spacing = 8
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    // 서점의 기본 정보와 탑 디바이더를 담고있는 스택뷰
+    private lazy var summaryStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [topDivider, infoSummaryStackView])
+        stackView.axis = .vertical
+        stackView.spacing = padding24
+        stackView.distribution = .fill
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    // 요약 정보와 서점 설명 사이의 디바이더
+    private let middleDivider: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(named: "kindyLightGray")
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    // 서점 상세설명 레이블
+    private let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Happiness is good health and a bad memory.Time moves in one direction, memory in another. History is not a burden on the memory but an illumination of the soul. Happiness is good health and a bad memory. Time moves in one direction, memory in another. History is not a burden on the memory but an illumination of the soul. History is not a burden on the memory but an illumination of the soul."
+        label.font = UIFont.systemFont(ofSize: 17)
+        label.numberOfLines = 0
+        label.setLineSpacing(lineSpacing: 6)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    // 서점 상세설명과 미들 디바이더를 담고 있는 스택뷰
+    private lazy var descriptionStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [middleDivider, descriptionLabel])
+        stackView.axis = .vertical
+        stackView.spacing = padding24
+        stackView.distribution = .fill
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    // 서점 설명과 맵 뷰 사이의 디바이더
+    private let bottomDivider: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(named: "kindyLightGray")
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    // 지도 아이콘 이미지 뷰
+    private let mapIconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "map")
+        imageView.contentMode = .center
+        imageView.tintColor = UIColor(named: "kindyGray")
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    // 하단 서점 상세 주소 레이블
+    private let address: UILabel = {
+        let label = UILabel()
+        label.text = "경상북도 포항시 남구 효자동길10번길 32"
+        label.font = UIFont.systemFont(ofSize: 15)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private lazy var addressStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [mapIconImageView, address])
+        stackView.axis = .horizontal
+        stackView.spacing = 8
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    private let bookstoreMapView: MKMapView = {
+        let mapView = MKMapView()
+        mapView.layer.masksToBounds = true
+        mapView.layer.cornerRadius = 8
+        mapView.translatesAutoresizingMaskIntoConstraints = false
+        return mapView
+    }()
+
+    private lazy var bookstorePin: MKPointAnnotation = {
+        let pin = MKPointAnnotation()
+        guard let bookstoreName = nameLabel.text else { return pin }
+        pin.title = bookstoreName
+        pin.coordinate = bookstoreCoordinate
+        return pin
+    }()
+
+    private lazy var bookstoreMapStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [bottomDivider, addressStackView, bookstoreMapView])
+        stackView.axis = .vertical
+        stackView.spacing = 24
+        stackView.distribution = .fill
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    // MARK: init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .white
+        setupUI()
+        setupMapView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupUI() {
+        addSubview(mainScrollView)
+        bookstoreImageScrollView.backgroundColor = .lightGray
+
+        mainScrollView.addSubview(bookstoreImageScrollView)
+        mainScrollView.addSubview(imagePageControl)
+        mainScrollView.addSubview(headerStackView)
+        mainScrollView.addSubview(summaryStackView)
+        mainScrollView.addSubview(descriptionStackView)
+        mainScrollView.addSubview(bookstoreMapStackView)
+
+        // 고정값 UI들 설정
+        setupDividerConstraints()
+        setupIconConstraints()
+
+        NSLayoutConstraint.activate([
+            // 메인 스크롤뷰 설정
+            mainScrollView.topAnchor.constraint(equalTo: topAnchor),
+            mainScrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            mainScrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            mainScrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            // 서점 이미지뷰 설정
+            bookstoreImageScrollView.topAnchor.constraint(equalTo: mainScrollView.topAnchor, constant: -100),
+            bookstoreImageScrollView.leadingAnchor.constraint(equalTo: mainScrollView.leadingAnchor),
+            bookstoreImageScrollView.trailingAnchor.constraint(equalTo: mainScrollView.trailingAnchor),
+            bookstoreImageScrollView.heightAnchor.constraint(equalToConstant: 368),
+
+            imagePageControl.topAnchor.constraint(equalTo: bookstoreImageScrollView.bottomAnchor, constant: -padding24),
+            imagePageControl.leadingAnchor.constraint(equalTo: mainScrollView.leadingAnchor),
+            imagePageControl.trailingAnchor.constraint(equalTo: mainScrollView.trailingAnchor),
+            imagePageControl.bottomAnchor.constraint(equalTo: bookstoreImageScrollView.bottomAnchor, constant: -padding16),
+
+            // 서점 이름, 짧은 주소, 북마크 버튼뷰
+            nameStackView.heightAnchor.constraint(equalToConstant: 36),
+            shortAddressLabel.heightAnchor.constraint(equalToConstant: 25),
+            headerStackView.topAnchor.constraint(equalTo: bookstoreImageScrollView.bottomAnchor, constant: padding24),
+            headerStackView.leadingAnchor.constraint(equalTo: mainScrollView.leadingAnchor, constant: padding16),
+            headerStackView.trailingAnchor.constraint(equalTo: mainScrollView.trailingAnchor, constant: -padding16),
+
+            // 탑 디바이더와 서점 기본 정보뷰
+            summaryStackView.topAnchor.constraint(equalTo: headerStackView.bottomAnchor, constant: padding24),
+            summaryStackView.leadingAnchor.constraint(equalTo: mainScrollView.leadingAnchor, constant: padding16),
+            summaryStackView.trailingAnchor.constraint(equalTo: mainScrollView.trailingAnchor, constant: -padding16),
+
+            // 미들 디바이더와 서점 상세 정보뷰
+            descriptionStackView.topAnchor.constraint(equalTo: summaryStackView.bottomAnchor, constant: padding24),
+            descriptionStackView.leadingAnchor.constraint(equalTo: mainScrollView.leadingAnchor, constant: padding16),
+            descriptionStackView.trailingAnchor.constraint(equalTo: mainScrollView.trailingAnchor, constant: -padding16),
+
+            // 바텀 디바이더와 서점 지도뷰
+            bookstoreMapView.heightAnchor.constraint(equalToConstant: UIScreen.main.bounds.height * 0.36),
+            bookstoreMapStackView.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor, constant: padding24),
+            bookstoreMapStackView.leadingAnchor.constraint(equalTo: mainScrollView.leadingAnchor, constant: padding16),
+            bookstoreMapStackView.trailingAnchor.constraint(equalTo: mainScrollView.trailingAnchor, constant: -padding16),
+            bookstoreMapStackView.bottomAnchor.constraint(equalTo: mainScrollView.bottomAnchor, constant: -100)
+        ])
+    }
+
+    private func setupDividerConstraints() {
+        NSLayoutConstraint.activate([
+            topDivider.widthAnchor.constraint(equalToConstant: UIScreen.main.bounds.width - (padding16 * 2)),
+            topDivider.heightAnchor.constraint(equalToConstant: 1),
+
+            middleDivider.widthAnchor.constraint(equalToConstant: UIScreen.main.bounds.width - (padding16 * 2)),
+            middleDivider.heightAnchor.constraint(equalToConstant: 1),
+
+            bottomDivider.widthAnchor.constraint(equalToConstant: UIScreen.main.bounds.width - (padding16 * 2)),
+            bottomDivider.heightAnchor.constraint(equalToConstant: 1),
+        ])
+    }
+
+    private func setupIconConstraints() {
+        NSLayoutConstraint.activate([
+            bookmarkButton.heightAnchor.constraint(equalToConstant: 36),
+            bookmarkButton.widthAnchor.constraint(equalToConstant: 32),
+
+            telephoneIconImageView.widthAnchor.constraint(equalToConstant: 22),
+            telephoneIconImageView.heightAnchor.constraint(equalToConstant: 22),
+
+            instagrameIconImageView.widthAnchor.constraint(equalToConstant: 22),
+            instagrameIconImageView.heightAnchor.constraint(equalToConstant: 22),
+
+            businessHourIconImageView.widthAnchor.constraint(equalToConstant: 22),
+            businessHourIconImageView.heightAnchor.constraint(equalToConstant: 22),
+
+            mapIconImageView.widthAnchor.constraint(equalToConstant: 22),
+            mapIconImageView.widthAnchor.constraint(equalToConstant: 22),
+        ])
+    }
+
+    private func setupMapView() {
+        bookstoreMapView.setRegion(MKCoordinateRegion(center: bookstoreCoordinate, span: MKCoordinateSpan(latitudeDelta: 0.005, longitudeDelta: 0.005)), animated: true)
+        bookstoreMapView.addAnnotation(bookstorePin)
+    }
+
+    @objc private func instagramButtonTapped() {
+
+        guard let instagramAddress = bookstore?.contact.instagramURL else { return }
+        guard let url = URL(string: instagramAddress) else { return }
+        UIApplication.shared.open(url, options: [:])
+    }
     
 }

--- a/Kindy/Kindy/Views/Home/NearByBookstoreCollectionViewCell.swift
+++ b/Kindy/Kindy/Views/Home/NearByBookstoreCollectionViewCell.swift
@@ -103,6 +103,6 @@ final class NearByBookstoreCollectionViewCell: UICollectionViewCell {
     // MARK: Configure Cell
     func configureCell(_ bookstore: Bookstore) {
         nameLabel.text = bookstore.name
-        distanceLabel.text = "\(bookstore.distance / 1000)km"
+        distanceLabel.text = "\(bookstore.distance)km"
     }
 }

--- a/Kindy/Kindy/Views/Home/NoPermissionCollectionViewCell.swift
+++ b/Kindy/Kindy/Views/Home/NoPermissionCollectionViewCell.swift
@@ -34,7 +34,7 @@ final class NoPermissionCollectionViewCell: UICollectionViewCell {
     private let bottomLabel: UILabel = {
         let label = UILabel()
         label.font = .footnote
-        label.text = "휴대폰 설정 > 킨디 > 위치정보 접근 허용"
+        label.text = "휴대폰 설정 > Kindy > 위치정보 접근 허용"
         label.textColor = .kindyGray
         
         return label

--- a/Kindy/Kindy/Views/Home/NoPermissionCollectionViewCell.swift
+++ b/Kindy/Kindy/Views/Home/NoPermissionCollectionViewCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-// 위치 정보 수집 권한 없을때 내 주변 서점에 보여줄 셀
+// 위치 정보 수집 권한 없을때 내 주변 서점 섹션에 보여줄 셀
 final class NoPermissionCollectionViewCell: UICollectionViewCell {
     
     private let stackView: UIStackView = {


### PR DESCRIPTION
# 배경
- 위치 권한이 없을 때의 뷰가 없어서 권한이 없어도 아이템들이 보였었습니다.
- 리프레쉬 컨트롤을 통해 뷰를 당겨서 새로고침할 수 있습니다.
# 작업 내용
## 위치 권한 없을 때 셀
- 뷰모델의 섹션과 아이템 열거형에 noPermission 케이스를 추가했습니다.
- 섹션에 알맞은 레이아웃을 createLayout에서 설정해주었습니다.
- 아이템에 알맞은 데이터소스를 snapshot과 createDataSource에서 설정해주었습니다.
## 리프레쉬 컨트롤
- configureRefreshControl 함수를 통해 리프레쉬 컨트롤을 추가해주었습니다.
- 리프레쉬를 하면 데이터를 파이어베이스에서 다시 불러옵니다.
## User 이메일로 fetch하는 함수
- User 구조체를 firestore에 저장된 형식에 맞게 약간 수정했습니다.
- 유저의 이메일을 통해 fetch 해오는 fetchUser(by:) 함수를 FirestoreManager에 구현했습니다.
# 스크린샷
- 위치권한이 없을 때 내 주변 서점 섹션에 대한 뷰입니다.
- ![KakaoTalk_Photo_2022-11-10-12-01-26-1](https://user-images.githubusercontent.com/65343417/200990202-a4f8a393-949d-458c-ab5b-868409da273f.png)
