### PR TITLE
홈 검색 페이지, 내 주변 서점 목록 페이지, 지역별 서점 목록 페이지에 홈에서 넘겨주는 데이터를 받는 메소드를 구현했습니다.

### DIFF
--- a/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeSearchViewController.swift
@@ -19,7 +19,7 @@ final class HomeSearchViewController: UIViewController, UISearchResultsUpdating 
         return view
     }()
     // TODO: 파이어베이스 데이터 연결
-    private var firebaseData: [Bookstore] = []
+    private var receivedData: [Bookstore] = []
     
     private var filteredItems: [Bookstore] = []
     
@@ -94,7 +94,7 @@ final class HomeSearchViewController: UIViewController, UISearchResultsUpdating 
             searchText = searchString
             
             // TODO: 파이어베이스 데이터 연결
-            filteredItems = firebaseData.filter{ (item) -> Bool in
+            filteredItems = receivedData.filter{ (item) -> Bool in
                 item.name.components(separatedBy: " ").joined(separator: "").localizedCaseInsensitiveContains(searchString) || item.address.components(separatedBy: " ").joined(separator: "").localizedCaseInsensitiveContains(searchString)
             }
         } else {
@@ -103,6 +103,10 @@ final class HomeSearchViewController: UIViewController, UISearchResultsUpdating 
         }
         
         tableView.reloadData()
+    }
+    
+    func setupData(items: [Bookstore]) {
+        self.receivedData = items
     }
 }
 

--- a/Kindy/Kindy/View Controllers/RegionViewController.swift
+++ b/Kindy/Kindy/View Controllers/RegionViewController.swift
@@ -24,7 +24,7 @@ final class RegionViewController: UIViewController, UISearchResultsUpdating {
     // TODO: 파이어베이스 데이터 연결
     private var filteredItems: [Bookstore] = []
     
-    private var regionItems: [Bookstore] = []
+    private var receivedData: [Bookstore] = []
     
     private var regionName: String = ""
 
@@ -88,42 +88,42 @@ final class RegionViewController: UIViewController, UISearchResultsUpdating {
     // 서치바에 타이핑될 때 어떻게 할 건지 설정하는 함수 (유저의 검색에 반응하는 로직)
     func updateSearchResults(for searchController: UISearchController) {
         if let searchString = searchController.searchBar.text?.components(separatedBy: " ").joined(separator: ""), searchString.isEmpty == false {
-            filteredItems = regionItems.filter{ (item) -> Bool in
+            filteredItems = receivedData.filter{ (item) -> Bool in
                 item.name.components(separatedBy: " ").joined(separator: "").localizedCaseInsensitiveContains(searchString) || item.address.components(separatedBy: " ").joined(separator: "").localizedCaseInsensitiveContains(searchString)
             }
         } else {
-            filteredItems = regionItems
+            filteredItems = receivedData
         }
         
         tableView.reloadData()
     }
     
-    func setupData(regionName: String, item: [Bookstore]) {
+    func setupData(regionName: String, items: [Bookstore]) {
         self.regionName = regionName
-        self.regionItems = getBookstoreByRegion(item: item, region: regionName)
-        self.filteredItems = getBookstoreByRegion(item: item, region: regionName)
+        self.receivedData = getBookstoreByRegion(items: items, region: regionName)
+        self.filteredItems = getBookstoreByRegion(items: items, region: regionName)
     }
     
-    private func getBookstoreByRegion(item: [Bookstore], region: String) -> [Bookstore] {
+    private func getBookstoreByRegion(items: [Bookstore], region: String) -> [Bookstore] {
         switch region{
         case "전체":
-            return item
+            return items
         case "서울":
-            return item.filter{ $0.address.contains("서울특별시") }
+            return items.filter{ $0.address.contains("서울특별시") }
         case "강원":
-            return item.filter{ $0.address.contains("강원도") }
+            return items.filter{ $0.address.contains("강원도") }
         case "경기/인천":
-            return item.filter{ $0.address.contains("경기도") || $0.address.contains("인천광역시") }
+            return items.filter{ $0.address.contains("경기도") || $0.address.contains("인천광역시") }
         case "충청/대전":
-            return item.filter{ $0.address.contains("충청도") || $0.address.contains("대전광역시") || $0.address.contains("세종특별자치시") }
+            return items.filter{ $0.address.contains("충청도") || $0.address.contains("대전광역시") || $0.address.contains("세종특별자치시") }
         case "경북/대구":
-            return item.filter{ $0.address.contains("경상북도") || $0.address.contains("대구광역시")}
+            return items.filter{ $0.address.contains("경상북도") || $0.address.contains("대구광역시")}
         case "전라/광주":
-            return item.filter{ $0.address.contains("전라남도") || $0.address.contains("광주광역시") || $0.address.contains("전라북도") }
+            return items.filter{ $0.address.contains("전라남도") || $0.address.contains("광주광역시") || $0.address.contains("전라북도") }
         case "경남/울산/부산":
-            return item.filter{ $0.address.contains("경상남도") || $0.address.contains("울산광역시") || $0.address.contains("부산광역시") }
+            return items.filter{ $0.address.contains("경상남도") || $0.address.contains("울산광역시") || $0.address.contains("부산광역시") }
         case "제주":
-            return item.filter{ $0.address.contains("제주특별자치도") }
+            return items.filter{ $0.address.contains("제주특별자치도") }
         default:
             return []
         }

--- a/Kindy/Kindy/View Controllers/RegionViewController.swift
+++ b/Kindy/Kindy/View Controllers/RegionViewController.swift
@@ -98,12 +98,35 @@ final class RegionViewController: UIViewController, UISearchResultsUpdating {
         tableView.reloadData()
     }
     
-    func setupData(regionName: String) {
+    func setupData(regionName: String, item: [Bookstore]) {
         self.regionName = regionName
-        
-        // TODO: 파이어베이스 데이터 연결
-//        filteredItems = NewItems().getBookstoreByRegion(regionName)
-//        regionItems = NewItems().getBookstoreByRegion(regionName)
+        self.regionItems = getBookstoreByRegion(item: item, region: regionName)
+        self.filteredItems = getBookstoreByRegion(item: item, region: regionName)
+    }
+    
+    private func getBookstoreByRegion(item: [Bookstore], region: String) -> [Bookstore] {
+        switch region{
+        case "전체":
+            return item
+        case "서울":
+            return item.filter{ $0.address.contains("서울특별시") }
+        case "강원":
+            return item.filter{ $0.address.contains("강원도") }
+        case "경기/인천":
+            return item.filter{ $0.address.contains("경기도") || $0.address.contains("인천광역시") }
+        case "충청/대전":
+            return item.filter{ $0.address.contains("충청도") || $0.address.contains("대전광역시") || $0.address.contains("세종특별자치시") }
+        case "경북/대구":
+            return item.filter{ $0.address.contains("경상북도") || $0.address.contains("대구광역시")}
+        case "전라/광주":
+            return item.filter{ $0.address.contains("전라남도") || $0.address.contains("광주광역시") || $0.address.contains("전라북도") }
+        case "경남/울산/부산":
+            return item.filter{ $0.address.contains("경상남도") || $0.address.contains("울산광역시") || $0.address.contains("부산광역시") }
+        case "제주":
+            return item.filter{ $0.address.contains("제주특별자치도") }
+        default:
+            return []
+        }
     }
 }
 


### PR DESCRIPTION
# 배경
- 기존에는 더미 데이터 기준으로 설정되어 있었습니다.
- Home에서 서버로부터 받은 서점 데이터를 각 목록 페이지 (`HomeSearchViewController`, `NearbyViewController`, `RegionViewController`) 로 넘겨줘야 했습니다.


# 작업 내용
- 홈에서 넘겨주는 데이터를 받는 메소드를 구현했습니다.
- 생각해보니, 지역별 서점 뿐만 아니라 홈 검색, 내 주변 서점도 마찬가지인 것 같아, 동일하게 구현했습니다.
- 홈 검색 페이지, 내 주변 서점 목록 페이지, 지역별 서점 목록 페이지로 데이터를 넘겨주는 메소드를 구현했습니다.
- 홈 검색, 내 주변 서점 목록 : `setupData(items: [Bookstore])` 메소드
- 지역별 서점 : `setupData(items: [Bookstore], regionName: String)` 메소드 (지역 이름도 넘겨주기)
- Home에서 받아주는 data를 받아 `receivedData` 프로퍼티에 담고, 그것을 이용하는 형식입니다.


# 알림 사항
- @stemmmm  `HomeViewController` 에서 각 VC의 `setupData(items: )` 를 호출하면 됩니다.
