### PR TITLE
🍿 지역별 서점, 검색과 델리게이트 연결했습니다. + 마이페이지가 다시 돌아왔습니다.

### DIFF
--- a/Kindy/Kindy/View Controllers/HomeViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeViewController.swift
@@ -147,6 +147,7 @@ final class HomeViewController: UIViewController {
     // 네비게이션 바의 검색 버튼이 눌렸을때 실행되는 함수
     @objc func searchButtonTapped() {
         let homeSearchViewController = HomeSearchViewController()
+        homeSearchViewController.setupData(items: model.bookstores.map { $0.bookstore! })
         show(homeSearchViewController, sender: nil)
     }
     
@@ -512,6 +513,8 @@ extension HomeViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let section = dataSource.snapshot().sectionIdentifiers[indexPath.section]
         
+        let bookstore = model.bookstores.map { $0.bookstore! }
+        
         switch section {
         case .curations:
             let curation = model.curations.map { $0.curation! }.first!
@@ -521,15 +524,13 @@ extension HomeViewController: UICollectionViewDelegate {
             
             present(curationViewController, animated: true)
         case .bookstores:
-            let bookstore = model.bookstores.map { $0.bookstore! }[indexPath.item]
             let detailBookstoreViewController = DetailBookstoreViewController()
-            detailBookstoreViewController.bookstore = bookstore
+            detailBookstoreViewController.bookstore = bookstore[indexPath.item]
             
             navigationController?.pushViewController(detailBookstoreViewController, animated: true)
         case .nearbys:
-            let bookstore = model.bookstores.map { $0.bookstore! }[indexPath.item]
             let detailBookstoreViewController = DetailBookstoreViewController()
-            detailBookstoreViewController.bookstore = bookstore
+            detailBookstoreViewController.bookstore = bookstore[indexPath.item]
             
             navigationController?.pushViewController(detailBookstoreViewController, animated: true)
 //        case .bookmarks:
@@ -541,7 +542,7 @@ extension HomeViewController: UICollectionViewDelegate {
         case .regions:
             let model = model.regions[indexPath.item]
             let regionViewController = RegionViewController()
-            regionViewController.setupData(regionName: model.region!)
+            regionViewController.setupData(regionName: model.region!, items: bookstore)
             
             show(regionViewController, sender: nil)
         default:

--- a/Kindy/Kindy/View Controllers/My Page/DetailMyPageViewController.swift
+++ b/Kindy/Kindy/View Controllers/My Page/DetailMyPageViewController.swift
@@ -30,7 +30,7 @@ final class DetailMyPageViewController: UIViewController {
     
     private func setupNavigation() {
         navigationItem.title = navigationBarTitle
-        navigationController?.navigationBar.tintColor = UIColor(named: "kindyGreen")
+        navigationController?.navigationBar.tintColor = .black
         navigationController?.navigationBar.topItem?.backButtonTitle = ""
     }
 

--- a/Kindy/Kindy/View Controllers/My Page/MyPageViewController.swift
+++ b/Kindy/Kindy/View Controllers/My Page/MyPageViewController.swift
@@ -11,7 +11,7 @@ final class MyPageViewController: UIViewController {
     
     private let privacy = Privacy()
     // 라이선스를 추가해야하는 경우 라이선스랑 제보하기의 배열 내부 위치를 바꿔주시면 됩니다
-    private let cellTitle: [String] = ["북마크 한 서점", "독립서점 제보하기", "개인정보 처리방침", "라이선스"]
+    private let cellTitle: [String] = ["독립서점 제보하기", "북마크 한 서점", "개인정보 처리방침", "라이선스"]
     
     private let tableView: UITableView = {
         let tableView = UITableView()
@@ -29,8 +29,8 @@ final class MyPageViewController: UIViewController {
     }
     
     private func setupTableView() {
-//        tableView.dataSource = self
-//        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.delegate = self
         tableView.rowHeight = 56
         tableView.register(MyPageTableViewCell.self, forCellReuseIdentifier: "MyPageTableViewCell")
     }
@@ -58,7 +58,7 @@ extension MyPageViewController: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "MyPageTableViewCell", for: indexPath) as? MyPageTableViewCell else { return UITableViewCell() }
         cell.myPageCellLabel.text = cellTitle[indexPath.row]
         
-        if cell.myPageCellLabel.text == "개인정보 처리방침" || cell.myPageCellLabel.text == "라이선스"  {
+        if cell.myPageCellLabel.text == "개인정보 처리방침" || cell.myPageCellLabel.text == "라이선스" || cell.myPageCellLabel.text == "북마크 한 서점"  {
             cell.isHidden = true
         }
         return cell
@@ -66,38 +66,40 @@ extension MyPageViewController: UITableViewDataSource {
     
 }
 
-//extension MyPageViewController: UITableViewDelegate {
-//
-//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-//
-//        switch cellTitle[indexPath.row] {
-//        case "북마크 한 서점":
+extension MyPageViewController: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        switch cellTitle[indexPath.row] {
+        case "북마크 한 서점":
 //            let bookmarkVC = BookmarkViewController()
 //            bookmarkVC.setupData(items: NewItems.bookstoreDummy.filter{ $0.isFavorite })
 //            show(bookmarkVC, sender: nil)
 //            tableView.deselectRow(at: indexPath, animated: true)
-//
-//        case "개인정보 처리방침":
-//            let detailMyPageVC = DetailMyPageViewController()
-//            detailMyPageVC.navigationBarTitle = "개인정보 처리방침"
-//            detailMyPageVC.detailString = privacy.termsOfService
-//            show(detailMyPageVC, sender: nil)
-//
-//        case "라이선스":
-//            let detailMyPageVC = DetailMyPageViewController()
-//            detailMyPageVC.navigationBarTitle = "라이선스"
-//            detailMyPageVC.detailString = privacy.license
-//            show(detailMyPageVC, sender: nil)
-//
-//        case "독립서점 제보하기":
-//            tableView.deselectRow(at: indexPath, animated: true)
-//            tableView.reportButtonTapped()
-//
-//        default:
-//            print("TableView Delegate Error!")
-//            break
-//        }
-//
-//    }
-//
-//}
+            return
+        case "개인정보 처리방침":
+            let detailMyPageVC = DetailMyPageViewController()
+            detailMyPageVC.navigationBarTitle = "개인정보 처리방침"
+            detailMyPageVC.detailString = privacy.termsOfService
+            show(detailMyPageVC, sender: nil)
+
+        case "라이선스":
+            let detailMyPageVC = DetailMyPageViewController()
+            detailMyPageVC.navigationBarTitle = "라이선스"
+            detailMyPageVC.detailString = privacy.license
+            show(detailMyPageVC, sender: nil)
+
+        case "독립서점 제보하기":
+            tableView.deselectRow(at: indexPath, animated: true)
+            tableView.reportButtonTapped()
+
+        default:
+            print("TableView Delegate Error!")
+            break
+        }
+
+    }
+
+}

--- a/Kindy/Kindy/Views/MyPage/MyPageTableViewCell.swift
+++ b/Kindy/Kindy/Views/MyPage/MyPageTableViewCell.swift
@@ -18,7 +18,7 @@ final class MyPageTableViewCell: UITableViewCell {
     private let myPageCellImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = UIImage(systemName: "chevron.forward")
-        imageView.tintColor = UIColor(named: "kindyGreen")
+        imageView.tintColor = .black
         imageView.widthAnchor.constraint(equalToConstant: 14).isActive = true
         imageView.translatesAutoresizingMaskIntoConstraints = false
         return imageView


### PR DESCRIPTION
# 배경
- 기존에는 데이터가 넘어가지 않는 상황이었습니다.
# 작업 내용
- 네비게이션 바의 검색 버튼을 눌러서 이동하는 뷰에 서점 데이터를 넘겨줬습니다.
- 마찬가지로 지역별 서점 셀을 눌러서 이동하는 뷰에도 서점 데이터를 넘겨줬습니다.
- 서점이나 큐레이션의 지역적인 매핑이 반복된다 느껴 이를 추후 리팩토링 해볼 예정입니다.

- 마이페이지를 제가 주석 처리 잠시 해뒀는데 다시 돌려놨습니다.
- 북마크 페이지로 가는 셀은 일단 뺴뒀습니다.
- > 버튼의 색을 임의로 검은색으로 했습니다.
- 셀을 눌렀을때 선택 해제가 안됐어서(시각적으로) deselectRow 메서드로 되게 했습니다.
# 스크린샷
x