### PR TITLE
북마크 섹션을 다시 추가했습니다.

### DIFF
--- a/Kindy/Kindy.xcodeproj/project.pbxproj
+++ b/Kindy/Kindy.xcodeproj/project.pbxproj
@@ -77,7 +77,7 @@
 		7BCB1A07291633E300B357D5 /* Contact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB1A06291633E300B357D5 /* Contact.swift */; };
 		7BCB1A0A29163D7400B357D5 /* Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB1A0929163D7400B357D5 /* Description.swift */; };
 		7BCB1A0F291646B700B357D5 /* FirestoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB1A0E291646B700B357D5 /* FirestoreManager.swift */; };
-		7BDAE69D290504A900BC41E9 /* EmptyBookmarkCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BDAE69C290504A900BC41E9 /* EmptyBookmarkCollectionViewCell.swift */; };
+		7BDAE69D290504A900BC41E9 /* ExceptionBookmarkCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BDAE69C290504A900BC41E9 /* ExceptionBookmarkCollectionViewCell.swift */; };
 		7BDAE69F2905107900BC41E9 /* EmptyNearbyCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BDAE69E2905107900BC41E9 /* EmptyNearbyCollectionViewCell.swift */; };
 		7BDB89AB291A099900FB2F23 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BDB89AA291A099900FB2F23 /* User.swift */; };
 		7BDB89B1291A8D0F00FB2F23 /* test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BDB89B0291A8D0F00FB2F23 /* test.swift */; };
@@ -157,7 +157,7 @@
 		7BCB1A06291633E300B357D5 /* Contact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Contact.swift; sourceTree = "<group>"; };
 		7BCB1A0929163D7400B357D5 /* Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Description.swift; sourceTree = "<group>"; };
 		7BCB1A0E291646B700B357D5 /* FirestoreManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreManager.swift; sourceTree = "<group>"; };
-		7BDAE69C290504A900BC41E9 /* EmptyBookmarkCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyBookmarkCollectionViewCell.swift; sourceTree = "<group>"; };
+		7BDAE69C290504A900BC41E9 /* ExceptionBookmarkCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExceptionBookmarkCollectionViewCell.swift; sourceTree = "<group>"; };
 		7BDAE69E2905107900BC41E9 /* EmptyNearbyCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyNearbyCollectionViewCell.swift; sourceTree = "<group>"; };
 		7BDB89AA291A099900FB2F23 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		7BDB89B0291A8D0F00FB2F23 /* test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = test.swift; sourceTree = "<group>"; };
@@ -385,7 +385,7 @@
 				7B404C2A28FFD3CF00A24C89 /* RegionCollectionViewCell.swift */,
 				7BF9AACC2909200100C80F72 /* NoPermissionCollectionViewCell.swift */,
 				7BDAE69E2905107900BC41E9 /* EmptyNearbyCollectionViewCell.swift */,
-				7BDAE69C290504A900BC41E9 /* EmptyBookmarkCollectionViewCell.swift */,
+				7BDAE69C290504A900BC41E9 /* ExceptionBookmarkCollectionViewCell.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -593,7 +593,7 @@
 				77DCB1502902987700EAB5D5 /* NearbyViewController.swift in Sources */,
 				7B7E2125290E20E200B6723D /* BusinessHour.swift in Sources */,
 				A06954F42907C84A00C09D1D /* DetailMyPageView.swift in Sources */,
-				7BDAE69D290504A900BC41E9 /* EmptyBookmarkCollectionViewCell.swift in Sources */,
+				7BDAE69D290504A900BC41E9 /* ExceptionBookmarkCollectionViewCell.swift in Sources */,
 				6EE5E42E290571BC00EA7413 /* PagingCurationViewController.swift in Sources */,
 				6E2AA45D290791480049E445 /* CurationTextCell.swift in Sources */,
 				A06954EF2906D9D800C09D1D /* Privacy.swift in Sources */,

--- a/Kindy/Kindy.xcodeproj/project.pbxproj
+++ b/Kindy/Kindy.xcodeproj/project.pbxproj
@@ -319,7 +319,6 @@
 		7B404C0C28FE87DF00A24C89 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				3101BC4E291BF27700C46195 /* Login */,
 				7B404C2D29016C7500A24C89 /* Supplementary */,
 				7B404C2C29016BDF00A24C89 /* Home */,
 				77DCB16B29053B9D00EAB5D5 /* HomeSearch */,
@@ -330,6 +329,7 @@
 				77DCB1812909086500EAB5D5 /* EmptyView */,
 				7BF9AACE2909743400C80F72 /* Detail */,
 				A06954F02907C81600C09D1D /* MyPage */,
+				3101BC4E291BF27700C46195 /* Login */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -383,8 +383,8 @@
 				7B404C2628FFD36E00A24C89 /* NearByBookstoreCollectionViewCell.swift */,
 				7B404C2828FFD3B000A24C89 /* BookmarkedCollectionViewCell.swift */,
 				7B404C2A28FFD3CF00A24C89 /* RegionCollectionViewCell.swift */,
-				7BDAE69E2905107900BC41E9 /* EmptyNearbyCollectionViewCell.swift */,
 				7BF9AACC2909200100C80F72 /* NoPermissionCollectionViewCell.swift */,
+				7BDAE69E2905107900BC41E9 /* EmptyNearbyCollectionViewCell.swift */,
 				7BDAE69C290504A900BC41E9 /* EmptyBookmarkCollectionViewCell.swift */,
 			);
 			path = Home;

--- a/Kindy/Kindy/Managers/FirestoreManager.swift
+++ b/Kindy/Kindy/Managers/FirestoreManager.swift
@@ -17,8 +17,7 @@ struct FirestoreManager {
     let users = db.collection("Users")
 }
 
-// MARK: - 큐레이션
-
+// MARK: 큐레이션
 extension FirestoreManager {
     // 모든 큐레이션 fetch
     func fetchCurations() async throws -> [Curation] {
@@ -39,8 +38,7 @@ extension FirestoreManager {
     }
 }
 
-// MARK: -  서점
-
+// MARK: 서점
 extension FirestoreManager {
     // 모든 서점 fetch
     func fetchBookstores() async throws -> [Bookstore] {
@@ -61,8 +59,7 @@ extension FirestoreManager {
     }
 }
 
-// MARK: -  유저
-
+// MARK: 유저
 extension FirestoreManager {
     // 유저 추가
     func add(user email: String, nickName: String) throws {
@@ -85,8 +82,7 @@ extension FirestoreManager {
     }
 }
 
-// MARK: - 이미지
-
+// MARK: 이미지
 extension FirestoreManager {
     enum ImageRequestError: Error {
         case couldNotInitializeFromData
@@ -94,7 +90,9 @@ extension FirestoreManager {
     }
     
     func fetchImage(with url: String?) async throws -> UIImage {
-        let (data, response) = try await URLSession.shared.data(from: URL(string: url ?? "")!)
+        guard let url = URL(string: url ?? "") else { return UIImage() }
+        
+        let (data, response) = try await URLSession.shared.data(from: url)
         
         guard let httpResponse = response as? HTTPURLResponse,
               httpResponse.statusCode == 200 else {
@@ -109,11 +107,8 @@ extension FirestoreManager {
     }
 }
 
-
-
 // MARK: Authentication
 extension FirestoreManager {
-    
     // 현재 로그인이 되어 있는지 확인하는 함수
     func isLoggedIn() -> Bool {
         return Auth.auth().currentUser == nil ? false : true
@@ -129,22 +124,27 @@ extension FirestoreManager {
     }
 }
 
-
-// MARK: Bookmark
+// MARK: 북마크
 extension FirestoreManager {
-    // User의 bookmarkedBookstores 의 값을 바꿔주는 함수(북마크 버튼을 누를 때 호출)
-    // 추후 추가가 되었는지 안되었는지 확인할 수 있게 return true를 해줄 수 있으면 좋을 듯.....
+    // User의 bookmarkedBookstores 의 값을 바꿔주는 함수 (북마크 버튼을 누를 때 호출)
     func updateBookmark(email: String, provider: String, bookmarkedBookstores: [String]) async throws {
-        users.whereField("email", isEqualTo: email).whereField("provider", isEqualTo: provider).getDocuments() { (querySnapshot, err) in
-            if let err = err {
-                print(err)
-            } else {
-                let document = querySnapshot!.documents.first
-                document?.reference.updateData([
-                    "bookmarkedBookstores" : bookmarkedBookstores
-                ])
-                
+        let querySnapshot = try await users.whereField("email", isEqualTo: email).whereField("provider", isEqualTo: provider).getDocuments()
+        let document = querySnapshot.documents.first
+        try await document?.reference.updateData(["bookmarkedBookstores" : bookmarkedBookstores])
+    }
+    
+    // 유저가 가진 서점 id 값으로 북마크된 서점 fetch
+    func fetchBookmarkedBookstores() async throws -> [Bookstore] {
+        if isLoggedIn() {
+            let user = try await fetchCurrentUser()
+            var bookmarkedBookstores = [Bookstore]()
+            for index in user.bookmarkedBookstores.indices {
+                bookmarkedBookstores.append(try await fetchBookstore(with: user.bookmarkedBookstores[index]))
             }
+            
+            return bookmarkedBookstores
+        } else {
+            return []
         }
     }
 }

--- a/Kindy/Kindy/Models/Home/Model.swift
+++ b/Kindy/Kindy/Models/Home/Model.swift
@@ -11,7 +11,7 @@ struct Model {
     var curations = [ViewModel.Item]()
     var bookstores = [ViewModel.Item]()
     var featuredBookstores = [ViewModel.Item]()
-    
+    var bookmarkedBookstores = [ViewModel.Item]()
     var regions: [ViewModel.Item] = [
         .region("전체"),
         .region("서울"),

--- a/Kindy/Kindy/Models/Home/ViewModel.swift
+++ b/Kindy/Kindy/Models/Home/ViewModel.swift
@@ -12,7 +12,7 @@ enum ViewModel {
         case curations
         case bookstores
         case nearbys
-        case bookmarks
+        case bookmarks, emptyBookmarks
         case regions
         case noPermission
     }
@@ -20,8 +20,8 @@ enum ViewModel {
     enum Item: Hashable {
         case curation(Curation)
         case featuredBookstore(Bookstore)
-        case nearByBookstore(Bookstore)
-        case bookmarkedBookstore(Bookstore)
+        case nearbyBookstore(Bookstore)
+        case bookmarkedBookstore(Bookstore), noBookmarkedBookstore
         case region(String)
         case noPermission
         
@@ -37,7 +37,7 @@ enum ViewModel {
             switch self {
             case .featuredBookstore(let bookstore):
                 return bookstore
-            case .nearByBookstore(let bookstore):
+            case .nearbyBookstore(let bookstore):
                 return bookstore
             case .bookmarkedBookstore(let bookstore):
                 return bookstore

--- a/Kindy/Kindy/View Controllers/HomeViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeViewController.swift
@@ -97,7 +97,7 @@ final class HomeViewController: UIViewController {
         collectionView.register(BookmarkedCollectionViewCell.self, forCellWithReuseIdentifier: BookmarkedCollectionViewCell.identifier)
         collectionView.register(RegionCollectionViewCell.self, forCellWithReuseIdentifier: RegionCollectionViewCell.identifier)
         collectionView.register(EmptyNearbyCollectionViewCell.self, forCellWithReuseIdentifier: EmptyNearbyCollectionViewCell.identifier)
-        collectionView.register(EmptyBookmarkCollectionViewCell.self, forCellWithReuseIdentifier: EmptyBookmarkCollectionViewCell.identifier)
+        collectionView.register(ExceptionBookmarkCollectionViewCell.self, forCellWithReuseIdentifier: ExceptionBookmarkCollectionViewCell.identifier)
         collectionView.register(NoPermissionCollectionViewCell.self, forCellWithReuseIdentifier: NoPermissionCollectionViewCell.identifier)
         
         // Supplementary View Registeration
@@ -468,7 +468,7 @@ final class HomeViewController: UIViewController {
                 
                 return cell
             case .emptyBookmarks:
-                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: EmptyBookmarkCollectionViewCell.identifier, for: indexPath) as? EmptyBookmarkCollectionViewCell else { return UICollectionViewCell() }
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ExceptionBookmarkCollectionViewCell.identifier, for: indexPath) as? ExceptionBookmarkCollectionViewCell else { return UICollectionViewCell() }
                 cell.label.text = firestoreManager.isLoggedIn() ? "북마크한 서점이 아직 없어요" : "로그인 후 이용할 수 있는 서비스입니다."
                 return cell
             }

--- a/Kindy/Kindy/View Controllers/HomeViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeViewController.swift
@@ -15,12 +15,14 @@ final class HomeViewController: UIViewController {
     // MARK: Tasks
     private var bookstoresRequestTask: Task<Void, Never>?
     private var curationsRequestTask: Task<Void, Never>?
+    private var bookmarkedBookstoresRequestTask: Task<Void, Never>?
     private var imageRequestTask: Task<Void, Never>?
     
     deinit {
         bookstoresRequestTask?.cancel()
         curationsRequestTask?.cancel()
         imageRequestTask?.cancel()
+        bookmarkedBookstoresRequestTask?.cancel()
     }
     
     // MARK: Managers
@@ -28,7 +30,6 @@ final class HomeViewController: UIViewController {
     private let locationManager = CLLocationManager()
     
     private var model = Model()
-    
     private var bookstores: [Bookstore] = []
     
     enum SupplementaryViewKind {
@@ -53,10 +54,18 @@ final class HomeViewController: UIViewController {
         switch locationManager.authorizationStatus {
         case .notDetermined, .denied, .restricted:
             snapshot.appendSections([.noPermission])
-            snapshot.appendItems([ViewModel.Item.noPermission])
+            snapshot.appendItems([.noPermission])
         default:
             snapshot.appendSections([.nearbys])
             snapshot.appendItems(model.bookstores)
+        }
+        
+        if model.bookmarkedBookstores.isEmpty || !firestoreManager.isLoggedIn() {
+            snapshot.appendSections([.emptyBookmarks])
+            snapshot.appendItems([.noBookmarkedBookstore])
+        } else {
+            snapshot.appendSections([.bookmarks])
+            snapshot.appendItems(model.bookmarkedBookstores)
         }
         
         snapshot.appendSections([.regions])
@@ -128,6 +137,7 @@ final class HomeViewController: UIViewController {
         curationsRequestTask?.cancel()
         bookstoresRequestTask?.cancel()
         imageRequestTask?.cancel()
+        bookmarkedBookstoresRequestTask?.cancel()
     }
     
     // MARK:  - Navigation Bar
@@ -192,21 +202,18 @@ final class HomeViewController: UIViewController {
         bookstoresRequestTask?.cancel()
         bookstoresRequestTask = Task {
             if var bookstores = try? await firestoreManager.fetchBookstores() {
-                
-                // 전체 데이터 add by X
+                // 전체 데이터에 추가
                 self.bookstores = bookstores
                 
                 switch locationManager.authorizationStatus {
                 case .authorizedWhenInUse, .authorizedAlways:
-                    model.bookstores = sortBookstoresByMyLocation(bookstores).map { .nearByBookstore($0) }
+                    model.bookstores = sortBookstoresByMyLocation(bookstores).map { .nearbyBookstore($0) }
                 default:
-                    model.bookstores = bookstores.map { .nearByBookstore($0) }
+                    model.bookstores = bookstores.map { .nearbyBookstore($0) }
                 }
                 
                 // TODO: 지금은 전체 데이터 수가 3개라 2개만 제거했지만 많아지면 반복문으로 교체(랜덤 로직도 추가)
                 model.featuredBookstores = [bookstores.removeLast(), bookstores.removeLast()].map { .featuredBookstore($0) }
-                
-                
             } else {
                 model.bookstores = []
                 model.featuredBookstores = []
@@ -214,6 +221,18 @@ final class HomeViewController: UIViewController {
             dataSource.apply(snapshot)
             
             bookstoresRequestTask = nil
+        }
+        
+        bookmarkedBookstoresRequestTask?.cancel()
+        bookmarkedBookstoresRequestTask = Task {
+            if let bookmarkedBookstores = try? await firestoreManager.fetchBookmarkedBookstores() {
+                model.bookmarkedBookstores = bookmarkedBookstores.map { .bookmarkedBookstore($0) }
+            } else {
+                model.bookmarkedBookstores = []
+            }
+            dataSource.apply(snapshot)
+
+            bookmarkedBookstoresRequestTask = nil
         }
     }
     
@@ -352,7 +371,7 @@ final class HomeViewController: UIViewController {
                 section.contentInsets = sectionContentInsets
                 
                 return section
-            case .noPermission:
+            case .noPermission, .emptyBookmarks:
                 let item = NSCollectionLayoutItem(layoutSize: fullSize)
                 
                 let groupSize = NSCollectionLayoutSize(
@@ -370,24 +389,6 @@ final class HomeViewController: UIViewController {
                 section.contentInsets = sectionContentInsets
                 
                 return section
-                //            case .emptyBookmark:
-                //                let item = NSCollectionLayoutItem(layoutSize: fullSize)
-                //
-                //                let groupSize = NSCollectionLayoutSize(
-                //                    widthDimension: .fractionalWidth(1),
-                //                    heightDimension: .estimated(150)
-                //                )
-                //                let group = NSCollectionLayoutGroup.horizontal(
-                //                    layoutSize: groupSize,
-                //                    subitem: item,
-                //                    count: 1
-                //                )
-                //
-                //                let section = NSCollectionLayoutSection(group: group)
-                //                section.boundarySupplementaryItems = [headerItem]
-                //                section.contentInsets = sectionContentInsets
-                //
-                //                return section
             }
         }
         
@@ -434,7 +435,7 @@ final class HomeViewController: UIViewController {
                 cell.configureCell(item.bookstore!)
                 
                 self.imageRequestTask = Task {
-                    if let image = try? await firestoreManager.fetchImage(with: item.bookstore?.images?[0]) {
+                    if let image = try? await firestoreManager.fetchImage(with: item.bookstore?.images?.first!) {
                         cell.imageView.image = image
                     }
                     imageRequestTask = nil
@@ -444,6 +445,13 @@ final class HomeViewController: UIViewController {
             case .bookmarks:
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BookmarkedCollectionViewCell.identifier, for: indexPath) as? BookmarkedCollectionViewCell else { return UICollectionViewCell() }
                 cell.configureCell(item.bookstore!)
+                
+                self.imageRequestTask = Task {
+                    if let image = try? await firestoreManager.fetchImage(with: item.bookstore?.images?.first!) {
+                        cell.imageView.image = image
+                    }
+                    imageRequestTask = nil
+                }
                 
                 return cell
             case .regions:
@@ -458,6 +466,10 @@ final class HomeViewController: UIViewController {
             case .noPermission:
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: NoPermissionCollectionViewCell.identifier, for: indexPath) as? NoPermissionCollectionViewCell else { return UICollectionViewCell() }
                 
+                return cell
+            case .emptyBookmarks:
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: EmptyBookmarkCollectionViewCell.identifier, for: indexPath) as? EmptyBookmarkCollectionViewCell else { return UICollectionViewCell() }
+                cell.label.text = firestoreManager.isLoggedIn() ? "북마크한 서점이 아직 없어요" : "로그인 후 이용할 수 있는 서비스입니다."
                 return cell
             }
         }
@@ -493,7 +505,7 @@ final class HomeViewController: UIViewController {
                     Task {
                         try await headerView.regionLabel.text = self.fetchMyLocation()
                     }
-                case .bookmarks:
+                case .bookmarks, .emptyBookmarks:
                     sectionName = "북마크 한 서점"
                     hideSeeAllButton = false
                     hideBottomStackView = true
@@ -542,12 +554,12 @@ extension HomeViewController: UICollectionViewDelegate {
             detailBookstoreViewController.bookstore = bookstore[indexPath.item]
             
             navigationController?.pushViewController(detailBookstoreViewController, animated: true)
-//        case .bookmarks:
-//
-//            let detailBookstoreViewController = DetailBookstoreViewController()
-//            detailBookstoreViewController.bookstore = bookstore
-//
-//            navigationController?.pushViewController(detailBookstoreViewController, animated: true)
+        case .bookmarks:
+            let bookmarkedBookstores = model.bookmarkedBookstores.map { $0.bookstore! }
+            let detailBookstoreViewController = DetailBookstoreViewController()
+            detailBookstoreViewController.bookstore = bookmarkedBookstores[indexPath.item]
+
+            navigationController?.pushViewController(detailBookstoreViewController, animated: true)
         case .regions:
             let model = model.regions[indexPath.item]
             let regionViewController = RegionViewController()
@@ -571,11 +583,11 @@ extension HomeViewController: SectionHeaderDelegate {
             let nearbyViewController = NearbyViewController()
             nearbyViewController.setupData(items: nearbyBookstores)
             show(nearbyViewController, sender: nil)
-//        case 3:
-//            let items = Item.bookmarkedBookStores.map { $0.bookstore! }
-//            let bookmarkViewController = BookmarkViewController()
-//            bookmarkViewController.setupData(items: items)
-//            show(bookmarkViewController, sender: nil)
+        case 3:
+            let bookmarkedBookstores = model.bookmarkedBookstores.map { $0.bookstore! }
+            let bookmarkViewController = BookmarkViewController()
+            bookmarkViewController.setupData(items: bookmarkedBookstores)
+            show(bookmarkViewController, sender: nil)
         default:
             return
         }
@@ -609,10 +621,10 @@ extension HomeViewController: CLLocationManagerDelegate {
         for i in 0..<bookstores.count {
             sortedBookstores[i].distance = Int(myLocation.distance(from: CLLocationCoordinate2D(latitude: sortedBookstores[i].location.latitude, longitude: sortedBookstores[i].location.longitude))) / 1000
         }
-        // TODO: 거리 범위 조절, 거리에 따라 m, km 조정 로직 구현 필요 + prefix(3)으로 3개만 보여주기
+        // TODO: 거리 범위 조절, 거리에 따라 m, km 조정 로직 구현 필요
         sortedBookstores = sortedBookstores.filter { $0.distance < 500 }.sorted { $0.distance < $1.distance }
         
-        return sortedBookstores
+        return Array(sortedBookstores.prefix(3))
     }
     
     // 내 위치의 지역을 문자열로 반환
@@ -636,7 +648,7 @@ extension HomeViewController: CLLocationManagerDelegate {
             manager.requestWhenInUseAuthorization()
             return
         case .authorizedWhenInUse, .authorizedAlways:
-            model.bookstores = sortBookstoresByMyLocation(model.bookstores.map { $0.bookstore! }).map { .nearByBookstore($0) }
+            model.bookstores = sortBookstoresByMyLocation(model.bookstores.map { $0.bookstore! }).map { .nearbyBookstore($0) }
             dataSource.apply(snapshot)
             return
         case .restricted, .denied:

--- a/Kindy/Kindy/Views/Home/BookmarkedCollectionViewCell.swift
+++ b/Kindy/Kindy/Views/Home/BookmarkedCollectionViewCell.swift
@@ -31,7 +31,7 @@ final class BookmarkedCollectionViewCell: UICollectionViewCell {
         return stackView
     }()
     
-    private let imageView: UIImageView = {
+    let imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.layer.cornerRadius = 8
         imageView.clipsToBounds = true

--- a/Kindy/Kindy/Views/Home/EmptyBookmarkCollectionViewCell.swift
+++ b/Kindy/Kindy/Views/Home/EmptyBookmarkCollectionViewCell.swift
@@ -21,10 +21,9 @@ final class EmptyBookmarkCollectionViewCell: UICollectionViewCell {
         return stackView
     }()
     
-    private let label: UILabel = {
+    let label: UILabel = {
         let label = UILabel()
         label.font = .body2
-        label.text = "북마크한 서점이 아직 없어요"
         
         return label
     }()
@@ -52,6 +51,8 @@ final class EmptyBookmarkCollectionViewCell: UICollectionViewCell {
     }
     
     private func setupView() {
+        button.isHidden = true
+        
         addSubview(stackView)
         stackView.addArrangedSubview(label)
         stackView.addArrangedSubview(button)

--- a/Kindy/Kindy/Views/Home/ExceptionBookmarkCollectionViewCell.swift
+++ b/Kindy/Kindy/Views/Home/ExceptionBookmarkCollectionViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  EmptyBookmarkCollectionViewCell.swift
+//  ExceptionBookmarkCollectionViewCell.swift
 //  Kindy
 //
 //  Created by 정호윤 on 2022/10/23.
@@ -7,8 +7,8 @@
 
 import UIKit
 
-// 북마크 섹션이 비었을때의 셀
-final class EmptyBookmarkCollectionViewCell: UICollectionViewCell {
+// 북마크 섹션이 비거나 로그인하지 않았을때 보여줄 셀
+final class ExceptionBookmarkCollectionViewCell: UICollectionViewCell {
     
     private let stackView: UIStackView = {
         let stackView = UIStackView()


### PR DESCRIPTION
# 배경
- 회원가입 기능이 생겨서 북마크 섹션을 부활시켜야했습니다.
# 작업 내용
- 북마크한 서점을 fetch 하는 메서드를 FirestoreManager에 구현했습니다.
- 북마크한 서점의 레이아웃과 데이터소스를 추가했습니다.
- 예외처리를 했습니다. (로그인 하지 않은 경우, 북마크한 서점의 개수가 0개인 경우)

## 기타 FirestoreManager 변경사항
- updateBookmark 함수를 async 함수로 리팩토링했습니다.
- fetchImage 함수에서 url이 없을때 강제 언래핑에서 바인딩을 통해 안전하게 언래핑하도록 변경했습니다.
# 스크린샷
|북마크 없을때|북마크 있을때|로그인 안 했을때|
|---|---|---|
|<img src ="https://user-images.githubusercontent.com/65343417/201465701-f51d93fc-1db9-43cb-ba64-84ac23bfe80a.png" width = "" height = "500"/>|<img src ="https://user-images.githubusercontent.com/65343417/201465695-ba50ded8-0bf4-44c7-bf86-5ce413b74ddd.png" width = "" height = "500"/>|<img src ="https://user-images.githubusercontent.com/65343417/201465702-8316eaba-add4-458c-8a64-ad8d462f01fa.png" width = "" height = "500"/>|