### PR TITLE
🍿 네비게이션 바 백 버튼 타이틀 삭제

### DIFF
--- a/Kindy/Kindy/Models/Curation/Curation.swift
+++ b/Kindy/Kindy/Models/Curation/Curation.swift
@@ -11,6 +11,7 @@ struct Curation {
     var id: String = UUID().uuidString
     let userID: String
     let bookstoreID: String
+    let mainImage: String
     let title: String
     let subTitle: String?
     var createdAt: Date? = Date()

--- a/Kindy/Kindy/View Controllers/HomeViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeViewController.swift
@@ -119,6 +119,7 @@ final class HomeViewController: UIViewController {
         let customNavBarAppearance = UINavigationBarAppearance()
         customNavBarAppearance.backgroundColor = .white
         
+        navigationController?.navigationBar.topItem?.title = ""
         navigationController?.navigationBar.standardAppearance = customNavBarAppearance
         navigationController?.navigationBar.scrollEdgeAppearance = customNavBarAppearance
         navigationController?.navigationBar.compactAppearance = customNavBarAppearance


### PR DESCRIPTION
# 배경
- 네비게이션 바 백 버튼 타이틀이 Back으로 나왔었습니다
# 작업 내용
- 이제 < 버튼만 보입니다.
# 스크린샷
<img src = "https://user-images.githubusercontent.com/65343417/201591848-7536f371-f133-4706-8beb-6e02d99cd2a1.png" width = "300">
