### PR TITLE
SignInViewController에서 유저 정보 확인 로직 분리

### DIFF
--- a/Kindy/Kindy.xcodeproj/project.pbxproj
+++ b/Kindy/Kindy.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		3101BC5B291BF30200C46195 /* SignUpDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3101BC5A291BF30200C46195 /* SignUpDelegate.swift */; };
 		3101BC5D291BF34400C46195 /* CheckPolicyDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3101BC5C291BF34400C46195 /* CheckPolicyDelegate.swift */; };
 		313C68DC2913F32B0061946E /* BookmarkSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 313C68DB2913F32B0061946E /* BookmarkSectionHeaderView.swift */; };
+		31F5A01E2925DF85002C1FAD /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F5A01D2925DF85002C1FAD /* SignInView.swift */; };
+		31F5A0202925E095002C1FAD /* SignInDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F5A01F2925E095002C1FAD /* SignInDelegate.swift */; };
 		31F7DD602904EAC6007E6E99 /* BookmarkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F7DD5F2904EAC6007E6E99 /* BookmarkViewController.swift */; };
 		31F7DD632904EAE9007E6E99 /* BookmarkCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F7DD622904EAE9007E6E99 /* BookmarkCollectionViewCell.swift */; };
 		31F7DD652904EB0C007E6E99 /* ImageCarouselCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F7DD642904EB0C007E6E99 /* ImageCarouselCollectionViewCell.swift */; };
@@ -98,6 +100,8 @@
 		3101BC5A291BF30200C46195 /* SignUpDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpDelegate.swift; sourceTree = "<group>"; };
 		3101BC5C291BF34400C46195 /* CheckPolicyDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckPolicyDelegate.swift; sourceTree = "<group>"; };
 		313C68DB2913F32B0061946E /* BookmarkSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkSectionHeaderView.swift; sourceTree = "<group>"; };
+		31F5A01D2925DF85002C1FAD /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
+		31F5A01F2925E095002C1FAD /* SignInDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInDelegate.swift; sourceTree = "<group>"; };
 		31F7DD5F2904EAC6007E6E99 /* BookmarkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkViewController.swift; sourceTree = "<group>"; };
 		31F7DD622904EAE9007E6E99 /* BookmarkCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkCollectionViewCell.swift; sourceTree = "<group>"; };
 		31F7DD642904EB0C007E6E99 /* ImageCarouselCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCarouselCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -203,6 +207,14 @@
 				3101BC58291BF2C800C46195 /* PolicySheetViewController.swift */,
 			);
 			path = Login;
+			sourceTree = "<group>";
+		};
+		31F5A01C2925D453002C1FAD /* SignIn */ = {
+			isa = PBXGroup;
+			children = (
+				31F5A01D2925DF85002C1FAD /* SignInView.swift */,
+			);
+			path = SignIn;
 			sourceTree = "<group>";
 		};
 		31F7DD612904EACE007E6E99 /* Bookmark */ = {
@@ -317,6 +329,7 @@
 		7B404C0C28FE87DF00A24C89 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				31F5A01C2925D453002C1FAD /* SignIn */,
 				7B404C2D29016C7500A24C89 /* Supplementary */,
 				7B404C2C29016BDF00A24C89 /* Home */,
 				77DCB16B29053B9D00EAB5D5 /* HomeSearch */,
@@ -350,6 +363,7 @@
 				31F7DD6829058A4C007E6E99 /* BookmarkDelegate.swift */,
 				3101BC5A291BF30200C46195 /* SignUpDelegate.swift */,
 				3101BC5C291BF34400C46195 /* CheckPolicyDelegate.swift */,
+				31F5A01F2925E095002C1FAD /* SignInDelegate.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -589,6 +603,7 @@
 				36B1B3842904102300C91825 /* DetailBookstoreView.swift in Sources */,
 				77DCB1502902987700EAB5D5 /* NearbyViewController.swift in Sources */,
 				7B7E2125290E20E200B6723D /* BusinessHour.swift in Sources */,
+				31F5A0202925E095002C1FAD /* SignInDelegate.swift in Sources */,
 				A06954F42907C84A00C09D1D /* DetailMyPageView.swift in Sources */,
 				7BDAE69D290504A900BC41E9 /* ExceptionBookmarkCollectionViewCell.swift in Sources */,
 				6EE5E42E290571BC00EA7413 /* PagingCurationViewController.swift in Sources */,
@@ -626,6 +641,7 @@
 				3101BC52291BF2A200C46195 /* CheckPolicyUIView.swift in Sources */,
 				3101BC5D291BF34400C46195 /* CheckPolicyDelegate.swift in Sources */,
 				6EE5E3EF28FECECE00EA7413 /* Curation.swift in Sources */,
+				31F5A01E2925DF85002C1FAD /* SignInView.swift in Sources */,
 				6EE5E3F128FECEE900EA7413 /* CurationViewController.swift in Sources */,
 				77DCB1632904462300EAB5D5 /* RegionCell.swift in Sources */,
 				31F7DD632904EAE9007E6E99 /* BookmarkCollectionViewCell.swift in Sources */,

--- a/Kindy/Kindy/Managers/FirestoreManager.swift
+++ b/Kindy/Kindy/Managers/FirestoreManager.swift
@@ -74,6 +74,7 @@ extension FirestoreManager {
     }
     
     // 현재 로그인되어 있는 정보로 유저 데이터 fetch
+    // MARK: 회원가입 로직 변경 후 수정 예정
     func fetchCurrentUser() async throws -> User {
         let auth = Auth.auth().currentUser
         let email = auth?.email
@@ -84,10 +85,23 @@ extension FirestoreManager {
             let user = try await users.document(Auth.auth().currentUser?.uid ?? "").getDocument(as: User.self)
             return user
         }
-        
-        
+    }
+    // 이미 존재하는 닉네임 확인
+    func isExistNickName(_ nickName: String) async throws -> Bool {
+        let nickNames = try await FirestoreManager.db.collection("Users").getDocuments().documents.map{ $0.data() }.filter{ String(describing: $0["nickName"]!) == nickName }
+        return nickNames.isEmpty ? false : true
+    }
+    // 이미 가입한 유저인지 확인
+    func isExistID(_ email: String?, _ provider: String) async throws -> Bool {
+        if let email = email {
+            return try await FirestoreManager.db.collection("Users").whereField("email", isEqualTo: email).whereField("provider", isEqualTo: provider).getDocuments().documents.map{ $0.documentID }.isEmpty ? false : true
+        } else {
+            return false
+        }
         
     }
+    
+    
     
     func deleteUser() {
         users.document(Auth.auth().currentUser?.uid ?? "al").delete() { _ in

--- a/Kindy/Kindy/Managers/FirestoreManager.swift
+++ b/Kindy/Kindy/Managers/FirestoreManager.swift
@@ -87,14 +87,14 @@ extension FirestoreManager {
         }
     }
     // 이미 존재하는 닉네임 확인
-    func isExistNickName(_ nickName: String) async throws -> Bool {
+    func isExistingNickname(_ nickName: String) async throws -> Bool {
         let nickNames = try await FirestoreManager.db.collection("Users").getDocuments().documents.map{ $0.data() }.filter{ String(describing: $0["nickName"]!) == nickName }
-        return nickNames.isEmpty ? false : true
+        return !nickNames.isEmpty
     }
     // 이미 가입한 유저인지 확인
-    func isExistID(_ email: String?, _ provider: String) async throws -> Bool {
+    func isExistingUser(_ email: String?, _ provider: String) async throws -> Bool {
         if let email = email {
-            return try await FirestoreManager.db.collection("Users").whereField("email", isEqualTo: email).whereField("provider", isEqualTo: provider).getDocuments().documents.map{ $0.documentID }.isEmpty ? false : true
+            return try await !FirestoreManager.db.collection("Users").whereField("email", isEqualTo: email).whereField("provider", isEqualTo: provider).getDocuments().documents.map{ $0.documentID }.isEmpty
         } else {
             return false
         }

--- a/Kindy/Kindy/Protocols/SignInDelegate.swift
+++ b/Kindy/Kindy/Protocols/SignInDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  SignInDelegate.swift
+//  Kindy
+//
+//  Created by Sooik Kim on 2022/11/17.
+//
+
+import Foundation
+
+protocol SignInDelegate: AnyObject {
+    func googleSignInMethod()
+    func appleSignInMethod()
+}

--- a/Kindy/Kindy/View Controllers/Login/PolicySheetViewController.swift
+++ b/Kindy/Kindy/View Controllers/Login/PolicySheetViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class PolicySheetViewController: UIViewController {
+final class PolicySheetViewController: UIViewController {
     
     private var labelTitle:String = ""
     var fromMyPage: Bool = false

--- a/Kindy/Kindy/View Controllers/Login/SignInViewController.swift
+++ b/Kindy/Kindy/View Controllers/Login/SignInViewController.swift
@@ -61,7 +61,7 @@ final class SignInViewController: UIViewController {
             
             let credential = GoogleAuthProvider.credential(withIDToken: idToken, accessToken: authentication.accessToken)
             Task {
-                if try await firestoreManager.isExistID(user?.profile?.email, "google") {
+                if try await firestoreManager.isExistingUser(user?.profile?.email, "google") {
                     Auth.auth().signIn(with: credential) { [weak self] result, error in
                         guard let self = self else { return }
                         guard
@@ -179,7 +179,7 @@ extension SignInViewController: ASAuthorizationControllerDelegate, ASAuthorizati
             // Sign in with Firebase.
             let checkEmail: String = self.decode(jwt:idTokenString) ?? ""
             Task{
-                if try await firestoreManager.isExistID(checkEmail, "apple") {
+                if try await firestoreManager.isExistingUser(checkEmail, "apple") {
                     Auth.auth().signIn(with: credential) { [weak self] result, error in
                         guard let self = self else { return }
                         guard result != nil, error == nil else {

--- a/Kindy/Kindy/View Controllers/Login/SignInViewController.swift
+++ b/Kindy/Kindy/View Controllers/Login/SignInViewController.swift
@@ -17,7 +17,7 @@ import FirebaseFirestoreSwift
 
 class SignInViewController: UIViewController {
     
-    let db = Firestore.firestore()
+    private let firestoreManager = FirestoreManager()
     
     fileprivate var currentNonce: String?
     
@@ -112,7 +112,7 @@ class SignInViewController: UIViewController {
         ])
     }
     
-    
+    // MARK: Google SignIn Button Action
     @objc private func googleSignIn() {
         guard let clientID = FirebaseApp.app()?.options.clientID else { return }
 
@@ -121,50 +121,42 @@ class SignInViewController: UIViewController {
 
         // Start the sign in flow!
         GIDSignIn.sharedInstance.signIn(with: config, presenting: self) { [unowned self] user, error in
+            if let error = error {
+                print(error.localizedDescription)
+                return
+            }
 
-          if let error = error {
-              print(error.localizedDescription)
-            return
-          }
-
-          guard
-            let authentication = user?.authentication,
-            let idToken = authentication.idToken
-          else {
-            return
-          }
-            let credential = GoogleAuthProvider.credential(withIDToken: idToken,
-                                                           accessToken: authentication.accessToken)
+            guard let authentication = user?.authentication, let idToken = authentication.idToken else { return }
             
-            
-            db.collection("Users").document(user?.profile?.email ?? "").getDocument{ (document, error) in
-                if let document = document, document.exists {
-                        let dataDescription = document.data().map(String.init(describing:)) ?? "nil"
-                        Auth.auth().signIn(with: credential) { [weak self] result, error in
-                            guard let self = self else { return }
-                            guard
-                                result != nil,
-                                error == nil else {
-                                if let error = error {
-                                    print("Error google Login - \(error) ")
-                                }
-                                return
+            let credential = GoogleAuthProvider.credential(withIDToken: idToken, accessToken: authentication.accessToken)
+            Task {
+                if try await firestoreManager.isExistID(user?.profile?.email, "google") {
+                    Auth.auth().signIn(with: credential) { [weak self] result, error in
+                        guard let self = self else { return }
+                        guard
+                            result != nil,
+                            error == nil else {
+                            if let error = error {
+                                print("Error google Login - \(error) ")
                             }
-                            // Auth.auth().currentUser.uid 값을 가지고 FireStore에 유저 컬렉션에 해당 도큐먼트가 있는지 확인
-                            // 확인 후 없다면 해당 유저 도큐먼트를
-                            self.navigationController?.popViewController(animated: true)
+                            return
                         }
-                    } else {
-                        let vc = SignUpViewController()
-                        vc.credential = credential
-                        vc.provider = "google"
-                        vc.email = user?.profile?.email ?? ""
-                        self.navigationController?.pushViewController(vc, animated: false)
+                        // Auth.auth().currentUser.uid 값을 가지고 FireStore에 유저 컬렉션에 해당 도큐먼트가 있는지 확인
+                        // 확인 후 없다면 해당 유저 도큐먼트를
+                        self.navigationController?.popViewController(animated: true)
                     }
+                } else {
+                    let vc = SignUpViewController()
+                    vc.credential = credential
+                    vc.provider = "google"
+                    vc.email = user?.profile?.email ?? ""
+                    self.navigationController?.pushViewController(vc, animated: false)
+                }
             }
         }
     }
-
+    
+    // MARK: Apple SignIn Button Action
     @available(iOS 13, *)
     @objc func startSignInWithAppleFlow() {
       //난수 생성
@@ -188,116 +180,108 @@ class SignInViewController: UIViewController {
 // Sign in with Apple 관련 사항
 @available(iOS 13.0, *)
 extension SignInViewController: ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
-    
+
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         return self.view.window!
     }
     
     // Adapted from https://auth0.com/docs/api-auth/tutorials/nonce#generate-a-cryptographically-random-nonce
+    // MARK: 난수 생성
     private func randomNonceString(length: Int = 32) -> String {
-      precondition(length > 0)
-      let charset: [Character] =
-        Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
-      var result = ""
-      var remainingLength = length
+        
+        precondition(length > 0)
+        
+        let charset: [Character] = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
 
-      while remainingLength > 0 {
-        let randoms: [UInt8] = (0 ..< 16).map { _ in
-          var random: UInt8 = 0
-          let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
-          if errorCode != errSecSuccess {
-            fatalError(
-              "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
-            )
-          }
-          return random
-        }
+        while remainingLength > 0 {
+            let randoms: [UInt8] = (0 ..< 16).map { _ in
+                var random: UInt8 = 0
+                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+                if errorCode != errSecSuccess {
+                    fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+                }
+                return random
+            }
 
         randoms.forEach { random in
-          if remainingLength == 0 {
-            return
-          }
-
-          if random < charset.count {
-            result.append(charset[Int(random)])
-            remainingLength -= 1
-          }
+            if remainingLength == 0 {
+                    return
+                }
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
         }
-      }
-
-      return result
+        return result
     }
     
     private func sha256(_ input: String) -> String {
-      let inputData = Data(input.utf8)
-      let hashedData = SHA256.hash(data: inputData)
-      let hashString = hashedData.compactMap {
-        String(format: "%02x", $0)
-      }.joined()
-
-      return hashString
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        let hashString = hashedData.compactMap { String(format: "%02x", $0) }.joined()
+        return hashString
     }
-
-  func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-    if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
-      guard let nonce = currentNonce else {
-        fatalError("Invalid state: A login callback was received, but no login request was sent.")
-      }
-      guard let appleIDToken = appleIDCredential.identityToken else {
-        print("Unable to fetch identity token")
-        return
-      }
-      guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
-        print("Unable to serialize token string from data: \(appleIDToken.debugDescription)")
-        return
-      }
+    
+    // MARK: 실제 로그인 작동하는 로직
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
+            guard let nonce = currentNonce else {
+                fatalError("Invalid state: A login callback was received, but no login request was sent.")
+            }
+            guard let appleIDToken = appleIDCredential.identityToken else {
+                print("Unable to fetch identity token")
+                return
+            }
+            guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+                print("Unable to serialize token string from data: \(appleIDToken.debugDescription)")
+                return
+            }
 
             // appleIDCredential.user , email fullName 등등으로 값을 확인할 수 있다 user는 identifier로 사용된다.
 
-      // Initialize a Firebase credential.
-      let credential = OAuthProvider.credential(withProviderID: "apple.com",
-                                                idToken: idTokenString,
-                                                rawNonce: nonce)
-      // Sign in with Firebase.
-        let checkEmail: String = self.decode(jwt:idTokenString) ?? ""
-        Task{
-            let documnetID = try await db.collection("Users").whereField("email", isEqualTo: checkEmail).whereField("provider", isEqualTo: "apple").getDocuments().documents.map{ $0.documentID }
-            if documnetID.isEmpty {
-                let vc = SignUpViewController()
-                vc.credential = credential
-                vc.provider = "apple"
-                vc.email = self.decode(jwt:idTokenString) ?? ""
-                self.navigationController?.pushViewController(vc, animated: true)
-            } else {
-                Auth.auth().signIn(with: credential) { [weak self] result, error in
-                    guard let self = self else { return }
-                    guard
-                        result != nil,
-                        error == nil else {
-                        if let error = error {
-                            print("Error google Login - \(error) ")
+            // Initialize a Firebase credential.
+            let credential = OAuthProvider.credential(withProviderID: "apple.com",
+                                idToken: idTokenString,
+                                rawNonce: nonce)
+            // Sign in with Firebase.
+            let checkEmail: String = self.decode(jwt:idTokenString) ?? ""
+            Task{
+                if try await firestoreManager.isExistID(checkEmail, "apple") {
+                    Auth.auth().signIn(with: credential) { [weak self] result, error in
+                        guard let self = self else { return }
+                        guard result != nil, error == nil else {
+                            if let error = error {
+                                print("Error google Login - \(error) ")
+                            }
+                            return
                         }
-                        return
+                        // Auth.auth().currentUser.uid 값을 가지고 FireStore에 유저 컬렉션에 해당 도큐먼트가 있는지 확인
+                        // 확인 후 없다면 해당 유저 도큐먼트를
+                        self.navigationController?.popViewController(animated: true)
                     }
-                    // Auth.auth().currentUser.uid 값을 가지고 FireStore에 유저 컬렉션에 해당 도큐먼트가 있는지 확인
-                    // 확인 후 없다면 해당 유저 도큐먼트를
-                    self.navigationController?.popViewController(animated: true)
+                } else {
+                    let vc = SignUpViewController()
+                    vc.credential = credential
+                    vc.provider = "apple"
+                    vc.email = self.decode(jwt:idTokenString) ?? ""
+                    self.navigationController?.pushViewController(vc, animated: true)
                 }
             }
-        }  
+        }
     }
-  }
 
-  func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-    print("Sign in with Apple errored: \(error)")
-  }
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        print("Sign in with Apple errored: \(error)")
+    }
 
 }
 
-
+// MARK: Apple에서 발행한 토큰값 decode
 extension SignInViewController {
-    
-    // 참조 : https://github.com/auth0/JWTDecode.swift/tree/master/JWTDecode
+    // 출처 : https://github.com/auth0/JWTDecode.swift/tree/master/JWTDecode
     private func base64UrlDecode(_ value: String) -> Data? {
         var base64 = value
             .replacingOccurrences(of: "-", with: "+")
@@ -358,8 +342,6 @@ extension SignInViewController {
             }
         }
     }
-
-
 
     public func decode(jwt: String) -> String? {
         let parts = jwt.components(separatedBy: ".")

--- a/Kindy/Kindy/View Controllers/Login/SignInViewController.swift
+++ b/Kindy/Kindy/View Controllers/Login/SignInViewController.swift
@@ -15,7 +15,7 @@ import FirebaseFirestore
 import FirebaseFirestoreSwift
 
 
-class SignInViewController: UIViewController {
+final class SignInViewController: UIViewController {
     
     private let firestoreManager = FirestoreManager()
     

--- a/Kindy/Kindy/View Controllers/Login/SignInViewController.swift
+++ b/Kindy/Kindy/View Controllers/Login/SignInViewController.swift
@@ -21,96 +21,27 @@ class SignInViewController: UIViewController {
     
     fileprivate var currentNonce: String?
     
-    private let descriptionLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.headline
-        label.textColor = UIColor.kindySecondaryGreen
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    } ()
-    
-    private let welcomeLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.headline
-        label.textColor = UIColor.kindyPrimaryGreen
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    } ()
-    
-    
-    private let googleLoginButton: GIDSignInButton = {
-        let button = GIDSignInButton()
-        button.style = .wide
-        button.layer.cornerRadius = 5
-        button.clipsToBounds = true
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
-    } ()
-
-    
-    private let appleLoginButton: ASAuthorizationAppleIDButton = {
-        let button = ASAuthorizationAppleIDButton(type: .signIn, style: .black)
-        button.cornerRadius = 5
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
-    } ()
-    
-    private let signoutButton: UIButton = {
-        let button = UIButton()
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
-    } ()
-    
+    private let signInView: SignInView = SignInView()
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationItem.title = "로그인"
         setupUI()
     }
     
     private func setupUI() {
+        self.navigationItem.title = "로그인"
         view.backgroundColor = .white
-        setupAppleSignInButton()
-        setupGoogleSignInButton()
-        setupLabel()
-    }
-    
-    private func setupLabel() {
-        descriptionLabel.text = "내 손 안의 독립서점"
-        welcomeLabel.text = "Kindy에 오신 것을 환영합니다"
-        view.addSubview(descriptionLabel)
-        view.addSubview(welcomeLabel)
+        signInView.translatesAutoresizingMaskIntoConstraints = false
+        signInView.delegate = self
+        view.addSubview(signInView)
         NSLayoutConstraint.activate([
-            welcomeLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            welcomeLabel.bottomAnchor.constraint(equalTo: appleLoginButton.topAnchor, constant: -56),
-            descriptionLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            descriptionLabel.bottomAnchor.constraint(equalTo: welcomeLabel.topAnchor, constant: -8)
+            signInView.topAnchor.constraint(equalTo: view.topAnchor),
+            signInView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            signInView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            signInView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
     }
     
-    private func setupGoogleSignInButton() {
-        googleLoginButton.addTarget(self, action: #selector(googleSignIn), for: .touchUpInside)
-        googleLoginButton.layer.frame.size = CGSize(width: view.frame.width - 32, height: 56)
-        view.addSubview(googleLoginButton)
-        NSLayoutConstraint.activate([
-            googleLoginButton.topAnchor.constraint(equalTo: view.centerYAnchor, constant: 8),
-            googleLoginButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            googleLoginButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
-            googleLoginButton.heightAnchor.constraint(equalToConstant: 56)
-        ])
-    }
-    
-    
-    private func setupAppleSignInButton() {
-        appleLoginButton.addTarget(self, action: #selector(startSignInWithAppleFlow), for: .touchUpInside)
-        view.addSubview(appleLoginButton)
-        NSLayoutConstraint.activate([
-            appleLoginButton.bottomAnchor.constraint(equalTo: view.centerYAnchor, constant: -8),
-            appleLoginButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            appleLoginButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
-            appleLoginButton.heightAnchor.constraint(equalToConstant: 56)
-        ])
-    }
     
     // MARK: Google SignIn Button Action
     @objc private func googleSignIn() {
@@ -175,7 +106,6 @@ class SignInViewController: UIViewController {
       authorizationController.performRequests()
     }
 }
-
 
 // Sign in with Apple 관련 사항
 @available(iOS 13.0, *)
@@ -355,4 +285,15 @@ extension SignInViewController {
         
     }
     
+}
+
+
+extension SignInViewController: SignInDelegate {
+    func googleSignInMethod() {
+        googleSignIn()
+    }
+    
+    func appleSignInMethod() {
+        startSignInWithAppleFlow()
+    }
 }

--- a/Kindy/Kindy/View Controllers/Login/SignUpViewController.swift
+++ b/Kindy/Kindy/View Controllers/Login/SignUpViewController.swift
@@ -10,7 +10,7 @@ import FirebaseFirestore
 import FirebaseAuth
 import FirebaseFirestoreSwift
 
-class SignUpViewController: UIViewController {
+final class SignUpViewController: UIViewController {
     
     let db = Firestore.firestore()
     

--- a/Kindy/Kindy/Views/Login/CheckPolicyUIView.swift
+++ b/Kindy/Kindy/Views/Login/CheckPolicyUIView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class CheckPolicyUIView: UIView {
     
-    var delegate: SignUpDelegate?
+    weak var delegate: SignUpDelegate?
     
     private var isTotalChecked: Bool = false {
         didSet {

--- a/Kindy/Kindy/Views/Login/CheckboxUIView.swift
+++ b/Kindy/Kindy/Views/Login/CheckboxUIView.swift
@@ -10,7 +10,7 @@ import UIKit
 class CheckboxUIView: UIView {
     
     
-    var delegate: CheckPolicyDelegate?
+    weak var delegate: CheckPolicyDelegate?
     var position: String = ""
     
     var isChecked: Bool = false {

--- a/Kindy/Kindy/Views/SignIn/SignInView.swift
+++ b/Kindy/Kindy/Views/SignIn/SignInView.swift
@@ -9,7 +9,7 @@ import UIKit
 import GoogleSignIn
 import AuthenticationServices
 
-class SignInView: UIView {
+final class SignInView: UIView {
     
     var delegate: SignInDelegate?
 

--- a/Kindy/Kindy/Views/SignIn/SignInView.swift
+++ b/Kindy/Kindy/Views/SignIn/SignInView.swift
@@ -11,7 +11,7 @@ import AuthenticationServices
 
 final class SignInView: UIView {
     
-    var delegate: SignInDelegate?
+    weak var delegate: SignInDelegate?
 
     private let descriptionLabel: UILabel = {
         let label = UILabel()

--- a/Kindy/Kindy/Views/SignIn/SignInView.swift
+++ b/Kindy/Kindy/Views/SignIn/SignInView.swift
@@ -1,0 +1,107 @@
+//
+//  SignInView.swift
+//  Kindy
+//
+//  Created by Sooik Kim on 2022/11/17.
+//
+
+import UIKit
+import GoogleSignIn
+import AuthenticationServices
+
+class SignInView: UIView {
+    
+    var delegate: SignInDelegate?
+
+    private let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.headline
+        label.textColor = UIColor.kindySecondaryGreen
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    } ()
+    
+    private let welcomeLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.headline
+        label.textColor = UIColor.kindyPrimaryGreen
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    } ()
+    
+    private let googleLoginButton: GIDSignInButton = {
+        let button = GIDSignInButton()
+        button.style = .wide
+        button.layer.cornerRadius = 5
+        button.clipsToBounds = true
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    } ()
+    
+    private let appleLoginButton: ASAuthorizationAppleIDButton = {
+        let button = ASAuthorizationAppleIDButton(type: .signIn, style: .black)
+        button.cornerRadius = 5
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    } ()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    override func layoutSubviews() {
+        setupAppleSignInButton()
+        setupGoogleSignInButton()
+        setupLabel()
+    }
+    
+    private func setupLabel() {
+        descriptionLabel.text = "내 손 안의 독립서점"
+        welcomeLabel.text = "Kindy에 오신 것을 환영합니다"
+        addSubview(descriptionLabel)
+        addSubview(welcomeLabel)
+        NSLayoutConstraint.activate([
+            welcomeLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            welcomeLabel.bottomAnchor.constraint(equalTo: appleLoginButton.topAnchor, constant: -56),
+            descriptionLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            descriptionLabel.bottomAnchor.constraint(equalTo: welcomeLabel.topAnchor, constant: -8)
+        ])
+    }
+    
+    private func setupGoogleSignInButton() {
+        googleLoginButton.addTarget(self, action: #selector(googleSignIn), for: .touchUpInside)
+        addSubview(googleLoginButton)
+        NSLayoutConstraint.activate([
+            googleLoginButton.topAnchor.constraint(equalTo: centerYAnchor, constant: 8),
+            googleLoginButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            googleLoginButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            googleLoginButton.heightAnchor.constraint(equalToConstant: 48)
+        ])
+    }
+    
+    
+    private func setupAppleSignInButton() {
+        appleLoginButton.addTarget(self, action: #selector(appleSignIn), for: .touchUpInside)
+        addSubview(appleLoginButton)
+        NSLayoutConstraint.activate([
+            appleLoginButton.bottomAnchor.constraint(equalTo: centerYAnchor, constant: -8),
+            appleLoginButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            appleLoginButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            appleLoginButton.heightAnchor.constraint(equalToConstant: 48)
+        ])
+    }
+    
+    @objc func googleSignIn() {
+        delegate?.googleSignInMethod()
+    }
+    
+    @objc func appleSignIn() {
+        delegate?.appleSignInMethod()
+    }
+    
+
+}


### PR DESCRIPTION
# 배경
 - 로그인 페이지에서 로그인 시도 시 기존 유저인지 확인하는 함수를 ViewController에서 분리 (첫번째 커밋)
 - MVC 패턴을 고려하여 ViewController와 View 를 분리 (두번째 커밋)

# 작업 내용
 ## 기존 유저인지 확인하는  isExistNickID 함수를 FireStoreManager로 이동
  - 기존 유저인지 확인할 때 email 과 provider로 Document 데이터에 접근하여 배열이 비어있으면 False, 존재하면 True 를 반환
  - 로그인 페이지엔선 함수 리턴값이 true 면 로그인 시도, false 라면 회원가입 페이지로 이동

 ## 기존 SignInView를 만들어 ViewController , View 를 분리
  - SignInView 파일 생성
  - 기존 뷰컨트롤러 내부에 선언된 View를 SignInView 로 분리
  - Delegate 패턴을 이용하여 버튼 로직 추가
 
 ## FireStoreManager에 이미 존재하는 닉네임인지 확인하는 isExistNickName 함수 추가
  -  유저 컬렉션 값을 가져와 입력한 String 값이 존재하는지 확인하는 함수로 유저닉네임 배열이 비어 있어 생성가능한 NickName이라면 false, 아니라면 True 를 반환 

# 스크린샷
 - 화면에 변화는 없음
