### PR TITLE
북마크리스트페이지에서 상세페이지 이동후 북마크 해제한 후 북마크 리스트에서 적용안되는 버그 수정

### DIFF
--- a/Kindy/Kindy/View Controllers/BookmarkViewController.swift
+++ b/Kindy/Kindy/View Controllers/BookmarkViewController.swift
@@ -14,6 +14,13 @@ final class BookmarkViewController: UIViewController {
     private let firestoreManager = FirestoreManager()
     
     private var user: User?
+    {
+        didSet {
+            totalData = totalData.filter{ user?.bookmarkedBookstores.contains( $0.id ) ?? false }
+            filterdItem = filterdItem.filter{ user?.bookmarkedBookstores.contains( $0.id ) ?? false }
+            dataSource.apply(filteredItemSnapshot)
+        }
+    }
     
     enum Section: Hashable {
         case bookmark


### PR DESCRIPTION
# 배경
 - 북마크페이지에서 상세페이지 이동 후 북마크를 해제한 후 뒤로 가기 버튼을 클릭하면 북마크된 서점 정보가 반영이 되지 않는 문제 발견
 
# 작업 내용
 - BookmarkViewController 의 user정보가 바뀌게 되면 북스토어 정보를 필터해준 후 datasource.applye 를 진행시켜주도록 수정

