### PR TITLE
🍿 (업데이트를 위한) 홈 디테일 수정

### DIFF
--- a/Kindy/Kindy/Extensions/Utility/Constants.swift
+++ b/Kindy/Kindy/Extensions/Utility/Constants.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+let padding8: CGFloat = 16
 let padding16: CGFloat = 16
 let padding24: CGFloat = 24
 

--- a/Kindy/Kindy/Extensions/Utility/Constants.swift
+++ b/Kindy/Kindy/Extensions/Utility/Constants.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-let padding8: CGFloat = 16
+let padding8: CGFloat = 8
 let padding16: CGFloat = 16
 let padding24: CGFloat = 24
 

--- a/Kindy/Kindy/Network Controllers/BookstoreRequest.swift
+++ b/Kindy/Kindy/Network Controllers/BookstoreRequest.swift
@@ -6,9 +6,7 @@
 //
 
 import Foundation
-import FirebaseFirestore
 import FirebaseFirestoreSwift
-import FirebaseAuth
 
 struct BookstoreRequest: FirestoreRequest {
     typealias Response = Bookstore
@@ -23,19 +21,15 @@ extension BookstoreRequest {
     
     // 유저가 가진 서점 id 값으로 북마크된 서점 fetch
     func fetchBookmarkedBookstores() async throws -> [Bookstore] {
-        let authManager = UserManager()
+        guard UserManager().isLoggedIn() else { return [] }
         
-        if authManager.isLoggedIn() {
-            let user = try await UserManager().fetchCurrentUser()
-            var bookmarkedBookstores = [Bookstore]()
-            
-            for index in user.bookmarkedBookstores.indices {
-                bookmarkedBookstores.append(try await fetch(with: user.bookmarkedBookstores[index]))
-            }
-
-            return bookmarkedBookstores
-        } else {
-            return []
+        let user = try await UserManager().fetchCurrentUser()
+        var bookmarkedBookstores = [Bookstore]()
+        
+        for index in user.bookmarkedBookstores.indices {
+            bookmarkedBookstores.append(try await fetch(with: user.bookmarkedBookstores[index]))
         }
+        
+        return bookmarkedBookstores
     }
 }

--- a/Kindy/Kindy/Network Controllers/CurationRequest.swift
+++ b/Kindy/Kindy/Network Controllers/CurationRequest.swift
@@ -6,9 +6,7 @@
 //
 
 import Foundation
-import FirebaseFirestore
 import FirebaseFirestoreSwift
-import FirebaseAuth
 
 struct CurationRequest: FirestoreRequest {
     typealias Response = Curation
@@ -16,12 +14,6 @@ struct CurationRequest: FirestoreRequest {
 }
 
 extension CurationRequest {
-    // 댓글을 포함한 큐레이션 fetch
-    func fetchWithComment(with id: String) async throws -> Curation {
-        let curation = try await db.collection(collectionPath).document(id).getDocument(as: Curation.self)
-        return curation
-    }
-    
     // 큐레이션 추가
     func add(curation: Curation) throws {
         try db.collection(collectionPath).document(curation.id).setData(from: curation)
@@ -33,8 +25,18 @@ extension CurationRequest {
         let document = querySnapshot.documents.first
         try await document?.reference.updateData(["likes" : likes])
     }
+    
+    func createComment(curationID: String, userID: String ,content: String) throws {
+        let comment = Comment(id: UUID().uuidString, userID: userID, content: content, createdAt: Date())
+        try db.collection(collectionPath).document(curationID).collection("Comment").document(comment.id).setData(from: comment)
+    }
+    
+    func deleteComment(curationID: String, commentID: String) {
+        db.collection(collectionPath).document(curationID).collection("Comment").document(commentID).delete()
+    }
+}
 
-    // 큐레이션이 가진 좋아요 값으로 fetch
+// 큐레이션이 가진 좋아요 값으로 fetch
 //    func fetchLikesCurtions() async throws -> [Curation] {
 //        if isLoggedIn() {
 //            let user = try await fetchCurrentUser()
@@ -47,13 +49,3 @@ extension CurationRequest {
 //            return []
 //        }
 //    }
-    
-    func createComment(curationID: String, userID: String ,content: String) throws {
-        let comment = Comment(id: UUID().uuidString, userID: userID, content: content, createdAt: Date())
-        try db.collection(collectionPath).document(curationID).collection("Comment").document(comment.id).setData(from: comment)
-    }
-    
-    func deleteComment(curationID: String, commentID: String) {
-        db.collection(collectionPath).document(curationID).collection("Comment").document(commentID).delete()
-    }
-}

--- a/Kindy/Kindy/Network Controllers/UserManager.swift
+++ b/Kindy/Kindy/Network Controllers/UserManager.swift
@@ -6,14 +6,12 @@
 //
 
 import Foundation
-import FirebaseFirestore
 import FirebaseFirestoreSwift
 import FirebaseAuth
 
 struct UserManager: FirestoreRequest {
     typealias Response = User
     let collectionPath = CollectionPath.users
-    let db = Firestore.firestore()
 }
 
 // MARK: 유저 데이터

--- a/Kindy/Kindy/View Controllers/HomeViewController.swift
+++ b/Kindy/Kindy/View Controllers/HomeViewController.swift
@@ -7,8 +7,6 @@
 
 import UIKit
 import CoreLocation
-import FirebaseFirestore
-import FirebaseFirestoreSwift
 
 final class HomeViewController: UIViewController {
     
@@ -91,14 +89,14 @@ final class HomeViewController: UIViewController {
         locationManager.requestWhenInUseAuthorization()
         locationManager.desiredAccuracy = kCLLocationAccuracyBest
         
-        // 큐레이션은 1번만 fetch
-        updateCuration()
+        updateCurations()
+        updateBookstores()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        update()
+        updateBookmarkedBookstores()
         
         // MARK: Nav Bar Appearance
         // 서점 상세화면으로 넘어갔다 오면 상세화면의 네비게이션 바 설정이 적용되기에 재설정
@@ -129,9 +127,9 @@ final class HomeViewController: UIViewController {
     
     // MARK:  - Navigation Bar
     
-    func createNavBarButtonItems() {
+    private func createNavBarButtonItems() {
         let scaledImage = UIImage(named: "KindyLogo")?.resizeImage(size: CGSize(width: 80, height: 20)).withRenderingMode(.alwaysOriginal)
-        navigationItem.leftBarButtonItem = UIBarButtonItem(image: scaledImage, style: .plain, target: nil, action: nil)
+        navigationItem.leftBarButtonItem = UIBarButtonItem(image: scaledImage, style: .plain, target: self, action: #selector(scrollToTop))
         
         let bellButton = UIBarButtonItem(image: UIImage(systemName: "bell"), style: .plain, target: self, action: #selector(bellButtonTapped))
         let searchButton = UIBarButtonItem(barButtonSystemItem: .search, target: self, action: #selector(searchButtonTapped))
@@ -143,27 +141,31 @@ final class HomeViewController: UIViewController {
         navigationItem.rightBarButtonItems = [searchButton]
     }
     
+    @objc private func scrollToTop() {
+        collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: true)
+    }
+    
     // 네비게이션 바의 검색 버튼이 눌렸을때 실행되는 함수
-    @objc func searchButtonTapped() {
+    @objc private func searchButtonTapped() {
         let homeSearchViewController = SearchViewController()
         homeSearchViewController.setupData(items: model.bookstores, itemType: .bookstoreType)
         show(homeSearchViewController, sender: nil)
     }
     
     // 네비게이션 바의 종 버튼이 눌렸을때 실행되는 함수
-    @objc func bellButtonTapped() {
+    @objc private func bellButtonTapped() {
         
     }
     
     // MARK: - Refresh Control
     
-    func configureRefreshControl() {
+    private func configureRefreshControl() {
         collectionView.refreshControl = UIRefreshControl()
         collectionView.refreshControl?.addTarget(self, action: #selector(handleRefreshControl), for: .valueChanged)
     }
     
     @objc func handleRefreshControl() {
-        update()
+        updateBookstores()
         
         DispatchQueue.main.async {
             self.collectionView.refreshControl?.endRefreshing()
@@ -172,7 +174,7 @@ final class HomeViewController: UIViewController {
     
     // MARK: - Update
     
-    func update() {
+    private func updateBookstores() {
         bookstoresTask?.cancel()
         bookstoresTask = Task {
             if let bookstores = try? await BookstoreRequest().fetch() {
@@ -202,7 +204,9 @@ final class HomeViewController: UIViewController {
             
             bookstoresTask = nil
         }
-        
+    }
+     
+    private func updateBookmarkedBookstores() {
         bookmarkedBookstoresTask?.cancel()
         bookmarkedBookstoresTask = Task {
             if let bookmarkedBookstores = try? await BookstoreRequest().fetchBookmarkedBookstores() {
@@ -216,7 +220,7 @@ final class HomeViewController: UIViewController {
         }
     }
     
-    func updateCuration() {
+    private func updateCurations() {
         curationsTask?.cancel()
         curationsTask = Task {
             if let curations = try? await CurationRequest().fetch() {
@@ -236,10 +240,6 @@ final class HomeViewController: UIViewController {
     private func createLayout() -> UICollectionViewLayout {
         let layout = UICollectionViewCompositionalLayout { sectionIndex, layoutEnvironment in
             let section = self.dataSource.snapshot().sectionIdentifiers[sectionIndex]
-            
-            // 재사용되는 edge inset을 정의했습니다.
-            let padding8: CGFloat = 8
-            let padding16: CGFloat = 16
             
             // MARK: Section Header
             let headerItemSize = NSCollectionLayoutSize(


### PR DESCRIPTION
# 배경
- viewWillAppear 마다 이런 서점은 어때요 섹션을 랜덤으로 보여주고 있었음 + 서점 데이터를 매번 불러왔음
- 접근 제어 키워드들이 제대로 설정 안돼있는 부분들이 있었음
- 불필요한 import가 많았었음
- 로고를 눌러도 깜빡이기만 하고 아무 반응이 없었음

# 작업 내용
- 서점, 북마크, 큐레이션 데이터를 불러오는 함수를 분리했습니다.
- 이제는 서점과 큐레이션 데이터를 viewDidLoad에서 불러옵니다 (북마크 한 서점은 viewWillAppear에서 불러옴)
- 빠져있는 private 키워드들을 적절하게 붙였습니다
- Firebase 관련 불필요한 import를 제거했습니다
- 이제 메인에서 로고를 누르면 맨위 아이템으로(큐레이션) 올라갑니다

# 영상
https://user-images.githubusercontent.com/65343417/203897644-9e8e8cbf-d27f-44ac-9112-25bde020852f.mov


