### PR TITLE
마이페이지에 내 글과 활동내역 기능을 추가했습니다.

### DIFF
--- a/Kindy/Kindy.xcodeproj/project.pbxproj
+++ b/Kindy/Kindy.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		31F7DD632904EAE9007E6E99 /* BookmarkCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F7DD622904EAE9007E6E99 /* BookmarkCollectionViewCell.swift */; };
 		31F7DD652904EB0C007E6E99 /* ImageCarouselCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F7DD642904EB0C007E6E99 /* ImageCarouselCollectionViewCell.swift */; };
 		31F7DD6929058A4C007E6E99 /* BookmarkDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F7DD6829058A4C007E6E99 /* BookmarkDelegate.swift */; };
+		36002A8A29325EBE00AE432A /* WritingListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36002A8929325EBE00AE432A /* WritingListViewController.swift */; };
 		361D54CF2901CABB00ACA11E /* DetailBookstoreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 361D54CE2901CABB00ACA11E /* DetailBookstoreViewController.swift */; };
 		363B56EF29263252008AF99C /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363B56EE29263252008AF99C /* Constants.swift */; };
 		36671EB429222E7E003BC7F7 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36671EB329222E7E003BC7F7 /* ImageCache.swift */; };
@@ -143,6 +144,7 @@
 		31F7DD622904EAE9007E6E99 /* BookmarkCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkCollectionViewCell.swift; sourceTree = "<group>"; };
 		31F7DD642904EB0C007E6E99 /* ImageCarouselCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCarouselCollectionViewCell.swift; sourceTree = "<group>"; };
 		31F7DD6829058A4C007E6E99 /* BookmarkDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkDelegate.swift; sourceTree = "<group>"; };
+		36002A8929325EBE00AE432A /* WritingListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritingListViewController.swift; sourceTree = "<group>"; };
 		361D54CE2901CABB00ACA11E /* DetailBookstoreViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailBookstoreViewController.swift; sourceTree = "<group>"; };
 		363B56EE29263252008AF99C /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		36671EB329222E7E003BC7F7 /* ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
@@ -519,6 +521,7 @@
 				369CC07A29241661000D7B96 /* EditNicknameViewController.swift */,
 				369CC07C29241681000D7B96 /* MyWritingViewController.swift */,
 				369CC07E292416A7000D7B96 /* MyActivitiesViewController.swift */,
+				36002A8929325EBE00AE432A /* WritingListViewController.swift */,
 			);
 			path = "My Page";
 			sourceTree = "<group>";
@@ -708,8 +711,8 @@
 				7BF9AACD2909200100C80F72 /* NoPermissionCell.swift in Sources */,
 				7B404C1B28FE89BA00A24C89 /* Bookstore.swift in Sources */,
 				315785312929EEFE008EC439 /* CurationCreateAddDescriptionButton.swift in Sources */,
-				7BDAE69F2905107900BC41E9 /* EmptyNearbyCollectionViewCell.swift in Sources */,
-				7B404C2B28FFD3CF00A24C89 /* RegionCollectionViewCell.swift in Sources */,
+				7BDAE69F2905107900BC41E9 /* EmptyNearbyCell.swift in Sources */,
+				7B404C2B28FFD3CF00A24C89 /* RegionNameCell.swift in Sources */,
 				7BDAE69F2905107900BC41E9 /* EmptyNearbyCell.swift in Sources */,
 				7B404C2B28FFD3CF00A24C89 /* RegionNameCell.swift in Sources */,
 				7BCB1A0A29163D7400B357D5 /* Description.swift in Sources */,
@@ -726,8 +729,7 @@
 				77DCB1502902987700EAB5D5 /* NearbyViewController.swift in Sources */,
 				7B7E2125290E20E200B6723D /* BusinessHour.swift in Sources */,
 				31F5A0202925E095002C1FAD /* SignInDelegate.swift in Sources */,
-				7BDAE69D290504A900BC41E9 /* ExceptionBookmarkCollectionViewCell.swift in Sources */,
-				A06954F42907C84A00C09D1D /* DetailMyPageView.swift in Sources */,
+				7BDAE69D290504A900BC41E9 /* ExceptionBookmarkCell.swift in Sources */,
 				7BDAE69D290504A900BC41E9 /* ExceptionBookmarkCell.swift in Sources */,
 				6EE5E42E290571BC00EA7413 /* PagingCurationViewController.swift in Sources */,
 				31578533292A778C008EC439 /* CurationCreateDescriptionTableViewCell.swift in Sources */,
@@ -736,8 +738,8 @@
 				3157852D2929EEE8008EC439 /* CurationCreateTitleView.swift in Sources */,
 				A06954EF2906D9D800C09D1D /* Privacy.swift in Sources */,
 				3157852F2929EEF3008EC439 /* CurationCreateHeadTextView.swift in Sources */,
-				7B404C2328FFD26100A24C89 /* CurationCollectionViewCell.swift in Sources */,
-				7B404C2728FFD36E00A24C89 /* NearByBookstoreCollectionViewCell.swift in Sources */,
+				7B404C2328FFD26100A24C89 /* CurationCell.swift in Sources */,
+				7B404C2728FFD36E00A24C89 /* NearByBookstoreCell.swift in Sources */,
 				7B404C2328FFD26100A24C89 /* CurationCell.swift in Sources */,
 				7B404C2728FFD36E00A24C89 /* NearByBookstoreCell.swift in Sources */,
 				7BCB1A07291633E300B357D5 /* Contact.swift in Sources */,
@@ -752,6 +754,7 @@
 				77DCB198291A706400EAB5D5 /* CurationListHeaderView.swift in Sources */,
 				36BD7D64290404C200CBC879 /* UILabel+.swift in Sources */,
 				77DCB15429029D1F00EAB5D5 /* UIButton+.swift in Sources */,
+				36002A8A29325EBE00AE432A /* WritingListViewController.swift in Sources */,
 				7BFE3BCF292BB6FF00370AC9 /* BookstoreRequest.swift in Sources */,
 				77DCB1612904457600EAB5D5 /* RegionViewController.swift in Sources */,
 				31F7DD6929058A4C007E6E99 /* BookmarkDelegate.swift in Sources */,

--- a/Kindy/Kindy.xcodeproj/project.pbxproj
+++ b/Kindy/Kindy.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		31F7DD652904EB0C007E6E99 /* ImageCarouselCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F7DD642904EB0C007E6E99 /* ImageCarouselCollectionViewCell.swift */; };
 		31F7DD6929058A4C007E6E99 /* BookmarkDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F7DD6829058A4C007E6E99 /* BookmarkDelegate.swift */; };
 		36002A8A29325EBE00AE432A /* WritingListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36002A8929325EBE00AE432A /* WritingListViewController.swift */; };
+		36002AAE2933AB5100AE432A /* NoWritingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36002AAD2933AB5100AE432A /* NoWritingView.swift */; };
 		361D54CF2901CABB00ACA11E /* DetailBookstoreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 361D54CE2901CABB00ACA11E /* DetailBookstoreViewController.swift */; };
 		363B56EF29263252008AF99C /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363B56EE29263252008AF99C /* Constants.swift */; };
 		36671EB429222E7E003BC7F7 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36671EB329222E7E003BC7F7 /* ImageCache.swift */; };
@@ -145,6 +146,7 @@
 		31F7DD642904EB0C007E6E99 /* ImageCarouselCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCarouselCollectionViewCell.swift; sourceTree = "<group>"; };
 		31F7DD6829058A4C007E6E99 /* BookmarkDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkDelegate.swift; sourceTree = "<group>"; };
 		36002A8929325EBE00AE432A /* WritingListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritingListViewController.swift; sourceTree = "<group>"; };
+		36002AAD2933AB5100AE432A /* NoWritingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoWritingView.swift; sourceTree = "<group>"; };
 		361D54CE2901CABB00ACA11E /* DetailBookstoreViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailBookstoreViewController.swift; sourceTree = "<group>"; };
 		363B56EE29263252008AF99C /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		36671EB329222E7E003BC7F7 /* ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
@@ -604,6 +606,7 @@
 				36E6CCE829236B4100E0F709 /* UserInfoContainerView.swift */,
 				36F6198A292406000085791C /* TryLoginContainerView.swift */,
 				36D881B8292951FC0089D2FF /* EditNicknameView.swift */,
+				36002AAD2933AB5100AE432A /* NoWritingView.swift */,
 			);
 			path = MyPage;
 			sourceTree = "<group>";
@@ -785,6 +788,7 @@
 				6EE5E3AF28FD318A00EA7413 /* MyPageViewController.swift in Sources */,
 				6E359EDF29278DF100139F6F /* CurationButtonItem.swift in Sources */,
 				36D881B9292951FC0089D2FF /* EditNicknameView.swift in Sources */,
+				36002AAE2933AB5100AE432A /* NoWritingView.swift in Sources */,
 				77DCB16A29053B9900EAB5D5 /* HomeSearchCell.swift in Sources */,
 				6E359EDD29278DC500139F6F /* LoginCheckable+.swift in Sources */,
 				6E359EEB29278EBC00139F6F /* CurationCommentCell.swift in Sources */,

--- a/Kindy/Kindy/Models/ImageCache.swift
+++ b/Kindy/Kindy/Models/ImageCache.swift
@@ -187,7 +187,7 @@ extension ImageCache {
         try await withThrowingTaskGroup(of: (String, UIImage).self) { group in
             for url in URLs {
                 group.addTask {
-                    let image = try? await ImageCache.shared.load(url)
+                    let image = try? await ImageCache.shared.load(url, size: ImageSize.big)
                     return (url, image ?? UIImage())
                 }
             }
@@ -201,7 +201,7 @@ extension ImageCache {
     }
     func loadImageArray(URLs: [String]) async throws -> [UIImage] {
         let images: [UIImage] = try await URLs.concurrentMap { url in
-            return try! await ImageCache.shared.load(url) ?? UIImage()
+            return try! await ImageCache.shared.load(url, size: ImageSize.big) ?? UIImage()
         }
         return images
     }

--- a/Kindy/Kindy/Network Controllers/CurationRequest.swift
+++ b/Kindy/Kindy/Network Controllers/CurationRequest.swift
@@ -39,31 +39,31 @@ extension CurationRequest {
     func deleteComment(curationID: String, commentID: String) {
         db.collection(collectionPath).document(curationID).collection("Comment").document(commentID).delete()
     }
-}
-
-// 큐레이션이 가진 좋아요 값으로 fetch
-//    func fetchLikesCurtions() async throws -> [Curation] {
-//        if isLoggedIn() {
-//            let user = try await fetchCurrentUser()
-//            var likesCurations = [Curation]()
-//            for index in user.curationLikes.indices {
-//                likesCurations.append(try await fetchCuration(with: user.curstionLikes[index]))
-//            }
-//            return likesCurations
-//        } else {
-//            return []
-//        }
-//    }
-
     
-    func createComment(curationID: String, userID: String ,content: String) throws {
-        let comment = Comment(id: UUID().uuidString, userID: userID, content: content, createdAt: Date())
-        try db.collection(collectionPath).document(curationID).collection("Comment").document(comment.id).setData(from: comment)
-    }
     
-    func deleteComment(curationID: String, commentID: String) {
-        db.collection(collectionPath).document(curationID).collection("Comment").document(commentID).delete()
-    }
+    // 큐레이션이 가진 좋아요 값으로 fetch
+    //    func fetchLikesCurtions() async throws -> [Curation] {
+    //        if isLoggedIn() {
+    //            let user = try await fetchCurrentUser()
+    //            var likesCurations = [Curation]()
+    //            for index in user.curationLikes.indices {
+    //                likesCurations.append(try await fetchCuration(with: user.curstionLikes[index]))
+    //            }
+    //            return likesCurations
+    //        } else {
+    //            return []
+    //        }
+    //    }
+    
+    
+    //    func createComment(curationID: String, userID: String ,content: String) throws {
+    //        let comment = Comment(id: UUID().uuidString, userID: userID, content: content, createdAt: Date())
+    //        try db.collection(collectionPath).document(curationID).collection("Comment").document(comment.id).setData(from: comment)
+    //    }
+    //
+    //    func deleteComment(curationID: String, commentID: String) {
+    //        db.collection(collectionPath).document(curationID).collection("Comment").document(commentID).delete()
+    //    }
     
     func uploadCurationImage(image: UIImage, pathRoot: String, completion: @escaping (String?) -> Void) {
         guard let imageData = image.jpegData(compressionQuality: 0.1) else { return }
@@ -90,6 +90,5 @@ extension CurationRequest {
                 print("delete Success")
             }
         }
-                                      
     }
 }

--- a/Kindy/Kindy/View Controllers/My Page/MyActivitiesViewController.swift
+++ b/Kindy/Kindy/View Controllers/My Page/MyActivitiesViewController.swift
@@ -86,12 +86,14 @@ extension MyActivitiesViewController: UITableViewDelegate {
         
         switch myActivitiesCellLabels[indexPath.row] {
         case "좋아요 한 글":
-            // TODO: 좋아요 한 큐레이션 페이지 불러오기
-            print("좋아요 한 글")
+            let writingListVC = WritingListViewController()
+            writingListVC.previousSelectedCell = .likeList
+            show(writingListVC, sender: nil)
 
-            // TODO: 댓글 단 큐레이션 페이지 불러오기
         case "댓글 단 글":
-            print("댓글 단 글")
+            let writingListVC = WritingListViewController()
+            writingListVC.previousSelectedCell = .commentList
+            show(writingListVC, sender: nil)
             
         default:
             break

--- a/Kindy/Kindy/View Controllers/My Page/MyActivitiesViewController.swift
+++ b/Kindy/Kindy/View Controllers/My Page/MyActivitiesViewController.swift
@@ -13,7 +13,7 @@ final class MyActivitiesViewController: UIViewController {
     private let myActivitiesCellLabels: [String] = ["좋아요 한 글", "댓글 단 글"]
     
     private let tableView: UITableView = {
-        let tableView = UITableView()
+        let tableView = UITableView(frame: .zero, style: .grouped)
         tableView.translatesAutoresizingMaskIntoConstraints = false
         return tableView
     }()
@@ -25,22 +25,37 @@ final class MyActivitiesViewController: UIViewController {
         setupUI()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        setupNavigationBar()
+        tabBarController?.tabBar.isHidden = true
+    }
+    
     // MARK: Helpers
     private func setupTableView() {
         tableView.dataSource = self
         tableView.delegate = self
         tableView.register(MyPageTableViewCell.self, forCellReuseIdentifier: "MyPageTableViewCell")
-        tableView.rowHeight = 56
+        tableView.rowHeight = 55
+        tableView.separatorStyle = .none
+        tableView.backgroundColor = .clear
     }
     
     private func setupUI() {
+        view.backgroundColor = .white
         view.addSubview(tableView)
         
         NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 32),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: padding16),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -padding16),
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
+    }
+    
+    private func setupNavigationBar() {
+        navigationController?.navigationBar.topItem?.title = ""
+        navigationController?.navigationBar.tintColor = UIColor.black
+        navigationItem.title = "활동 내역"
     }
     
 }

--- a/Kindy/Kindy/View Controllers/My Page/MyPageViewController.swift
+++ b/Kindy/Kindy/View Controllers/My Page/MyPageViewController.swift
@@ -107,6 +107,8 @@ final class MyPageViewController: UIViewController {
     private func setupAddTarget() {
         userInfoContainerView.nicknameEditButton.addTarget(self, action: #selector(nicknameEditButtonTapped), for: .touchUpInside)
         userInfoContainerView.bookmarkedBookstoreButton.addTarget(self, action: #selector(bookmarkedBookstoreButtonTapped), for: .touchUpInside)
+        userInfoContainerView.myWritingButton.addTarget(self, action: #selector(myWritingButtonTapped), for: .touchUpInside)
+        userInfoContainerView.myActivitiesButton.addTarget(self, action: #selector(myActivitiesButtonTapped), for: .touchUpInside)
         tryLoginContainerView.signInButton.addTarget(self, action: #selector(signInButtonTapped), for: .touchUpInside)
 //        tryLoginContainerView.signUpButton.addTarget(self, action: #selector(signUpButtonTapped), for: .touchUpInside)
     }
@@ -163,6 +165,18 @@ final class MyPageViewController: UIViewController {
         let bookmarkVC = BookmarkViewController()
         bookmarkVC.setupData(items: bookmarkedBookstores)
         show(bookmarkVC, sender: nil)
+    }
+    
+    @objc func myWritingButtonTapped() {
+//        let bookmarkVC = BookmarkViewController()
+//        bookmarkVC.setupData(items: bookmarkedBookstores)
+//        show(bookmarkVC, sender: nil)
+    }
+    
+    @objc func myActivitiesButtonTapped() {
+//        let myActivitiesVC = MyActivitiesViewController()
+//        
+//        show(myActivitiesVC, sender: nil)
     }
     
     @objc func signInButtonTapped() {

--- a/Kindy/Kindy/View Controllers/My Page/MyPageViewController.swift
+++ b/Kindy/Kindy/View Controllers/My Page/MyPageViewController.swift
@@ -71,7 +71,7 @@ final class MyPageViewController: UIViewController {
         tableView.dataSource = self
         tableView.delegate = self
         tableView.register(MyPageTableViewCell.self, forCellReuseIdentifier: "MyPageTableViewCell")
-        tableView.rowHeight = 56
+        tableView.rowHeight = 55
         tableView.separatorStyle = .none
         tableView.backgroundColor = .clear
     }
@@ -175,7 +175,7 @@ final class MyPageViewController: UIViewController {
     
     @objc func myActivitiesButtonTapped() {
 //        let myActivitiesVC = MyActivitiesViewController()
-//        
+//
 //        show(myActivitiesVC, sender: nil)
     }
     

--- a/Kindy/Kindy/View Controllers/My Page/MyPageViewController.swift
+++ b/Kindy/Kindy/View Controllers/My Page/MyPageViewController.swift
@@ -167,16 +167,17 @@ final class MyPageViewController: UIViewController {
         show(bookmarkVC, sender: nil)
     }
     
+    // TODO: 스몰톡 업데이트 되면 MyWritingViewController으로 연결
     @objc func myWritingButtonTapped() {
-//        let bookmarkVC = BookmarkViewController()
-//        bookmarkVC.setupData(items: bookmarkedBookstores)
-//        show(bookmarkVC, sender: nil)
+        let writingListVC = WritingListViewController()
+        writingListVC.previousSelectedCell = .myCuration
+        show(writingListVC, sender: nil)
     }
     
     @objc func myActivitiesButtonTapped() {
-//        let myActivitiesVC = MyActivitiesViewController()
-//
-//        show(myActivitiesVC, sender: nil)
+        let myActivitiesVC = MyActivitiesViewController()
+
+        show(myActivitiesVC, sender: nil)
     }
     
     @objc func signInButtonTapped() {

--- a/Kindy/Kindy/View Controllers/My Page/WritingListViewController.swift
+++ b/Kindy/Kindy/View Controllers/My Page/WritingListViewController.swift
@@ -1,0 +1,127 @@
+//
+//  WritingListViewController.swift
+//  Kindy
+//
+//  Created by WooriJoon on 2022/11/26.
+//
+
+import UIKit
+
+// 어느 셀을 누르고 들어왔는지 판단하기 위한 enum
+enum PreviousSelectedCell {
+    case myCuration
+//    case mySmallTalk
+    case likeList
+    case commentList
+}
+
+final class WritingListViewController: UIViewController {
+
+    // MARK: Properties
+    private var curationsRequestTask: Task<Void, Never>?
+    private var imageRequestTask: Task<Void, Never>?
+    private var userRequestTask: Task<Void, Never>?
+    
+    deinit {
+        curationsRequestTask?.cancel()
+        imageRequestTask?.cancel()
+        userRequestTask?.cancel()
+    }
+    
+    var previousSelectedCell: PreviousSelectedCell = .myCuration
+
+    private let writingTableView: UITableView = {
+        let tableView = UITableView()
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        return tableView
+    }()
+    
+    private let noWritingLable: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let noWritingButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    private var writings: [Curation] = []
+    
+    // MARK: LifeCycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupTableView()
+        setupUI()
+        
+    }
+    
+    // MARK: Helpers
+    private func setupTableView() {
+        writingTableView.dataSource = self
+        writingTableView.delegate = self
+        writingTableView.rowHeight = CurationListCell.rowHeight
+        writingTableView.register(CurationListCell.self, forCellReuseIdentifier: CurationListCell.identifier)
+    }
+    
+    private func setupUI() {
+        view.addSubview(writingTableView)
+        
+        NSLayoutConstraint.activate([
+            writingTableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            writingTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            writingTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            writingTableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+    
+    private func setupNavigationBar() {
+        navigationController?.navigationBar.topItem?.title = ""
+        navigationController?.navigationBar.tintColor = UIColor.black
+        
+        switch previousSelectedCell {
+        case .myCuration:
+            navigationItem.title = "내 글 목록"
+//        case .smallTalk:
+//            navigationItem.title = ""
+        case .likeList:
+            navigationItem.title = "좋아요 한 글"
+        case .commentList:
+            navigationItem.title = "댓글 단 글"
+        }
+    }
+    
+}
+
+// MARK: Extensions
+// MARK: UITableViewDataSource
+extension WritingListViewController: UITableViewDataSource {
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return writings.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: CurationListCell.identifier, for: indexPath) as? CurationListCell else { return UITableViewCell() }
+        cell.curation = writings[indexPath.row]
+        
+        imageRequestTask = Task {
+            let descriptions = writings[indexPath.row].descriptions
+            if let image = try? await ImageCache.shared.load(descriptions[indexPath.row].image) {
+                cell.photoImageView.image = image
+            } else {
+                cell.photoImageView.image = UIImage()
+            }
+            imageRequestTask = nil
+        }
+        return cell
+    }
+
+}
+
+// MARK: UITableViewDelegate
+extension WritingListViewController: UITableViewDelegate {
+    
+}

--- a/Kindy/Kindy/View Controllers/My Page/WritingListViewController.swift
+++ b/Kindy/Kindy/View Controllers/My Page/WritingListViewController.swift
@@ -84,19 +84,19 @@ final class WritingListViewController: UIViewController {
         
         switch previousSelectedCell {
         case .myCuration:
-            noWritingView.noWritingLable.text = "내 글이 메인에 소개될 기회를 잡아보세요!"
+            noWritingView.noWritingLabel.text = "내 글이 메인에 소개될 기회를 잡아보세요!"
             noWritingView.noWritingButton.setTitle("큐레이션 작성하기", for: .normal)
             noWritingView.noWritingButton.addTarget(self, action: #selector(writeCurationButtonTapped), for: .touchUpInside)
             
 //        case .smallTalk:
             
         case .likeList:
-            noWritingView.noWritingLable.text = "아직 좋아요 한 글이 없어요"
+            noWritingView.noWritingLabel.text = "아직 좋아요 한 글이 없어요"
             noWritingView.noWritingButton.setTitle("큐레이션 보러가기", for: .normal)
             noWritingView.noWritingButton.addTarget(self, action: #selector(readCurationsButtonTapped), for: .touchUpInside)
             
         case .commentList:
-            noWritingView.noWritingLable.text = "아직 댓글 단 글이 없어요"
+            noWritingView.noWritingLabel.text = "아직 댓글 단 글이 없어요"
             noWritingView.noWritingButton.setTitle("큐레이션 보러가기", for: .normal)
             noWritingView.noWritingButton.addTarget(self, action: #selector(readCurationsButtonTapped), for: .touchUpInside)
         }

--- a/Kindy/Kindy/View Controllers/My Page/WritingListViewController.swift
+++ b/Kindy/Kindy/View Controllers/My Page/WritingListViewController.swift
@@ -36,17 +36,8 @@ final class WritingListViewController: UIViewController {
         return tableView
     }()
     
-    private let noWritingLable: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-    
-    private let noWritingButton: UIButton = {
-        let button = UIButton()
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
-    }()
+    // 글이 없을때 보여줄 뷰
+    private let noWritingView = NoWritingView()
     
     private var writings: [Curation] = []
     
@@ -55,7 +46,12 @@ final class WritingListViewController: UIViewController {
         super.viewDidLoad()
         setupTableView()
         setupUI()
-        
+        fetchCurations()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        setupNavigationBar()
+        tabBarController?.tabBar.isHidden = true
     }
     
     // MARK: Helpers
@@ -67,14 +63,75 @@ final class WritingListViewController: UIViewController {
     }
     
     private func setupUI() {
-        view.addSubview(writingTableView)
+        view.backgroundColor = .white
+        guard !writings.isEmpty else {
+            setupNoWritingView()
+            return
+        }
         
+        view.addSubview(writingTableView)
         NSLayoutConstraint.activate([
             writingTableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             writingTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             writingTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             writingTableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
+    }
+    
+    private func setupNoWritingView() {
+        view.addSubview(noWritingView)
+        noWritingView.translatesAutoresizingMaskIntoConstraints = false
+        
+        switch previousSelectedCell {
+        case .myCuration:
+            noWritingView.noWritingLable.text = "내 글이 메인에 소개될 기회를 잡아보세요!"
+            noWritingView.noWritingButton.setTitle("큐레이션 작성하기", for: .normal)
+            noWritingView.noWritingButton.addTarget(self, action: #selector(writeCurationButtonTapped), for: .touchUpInside)
+            
+//        case .smallTalk:
+            
+        case .likeList:
+            noWritingView.noWritingLable.text = "아직 좋아요 한 글이 없어요"
+            noWritingView.noWritingButton.setTitle("큐레이션 보러가기", for: .normal)
+            noWritingView.noWritingButton.addTarget(self, action: #selector(readCurationsButtonTapped), for: .touchUpInside)
+            
+        case .commentList:
+            noWritingView.noWritingLable.text = "아직 댓글 단 글이 없어요"
+            noWritingView.noWritingButton.setTitle("큐레이션 보러가기", for: .normal)
+            noWritingView.noWritingButton.addTarget(self, action: #selector(readCurationsButtonTapped), for: .touchUpInside)
+        }
+        
+        noWritingView.noWritingButton.setUnderline()
+        NSLayoutConstraint.activate([
+            noWritingView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            noWritingView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            noWritingView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: padding16),
+            noWritingView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -padding16),
+            noWritingView.heightAnchor.constraint(equalToConstant: 60),
+        ])
+    }
+    
+    // TODO: 조건에 맞는 큐레이션 들고오기
+    private func fetchCurations() {
+//        curationsRequestTask?.cancel()
+//
+////        switch previousSelectedCell {
+////        case .myCuration:
+////            <#code#>
+////        case .likeList:
+////            <#code#>
+////        case .commentList:
+////            <#code#>
+////        }
+//        curationsRequestTask = Task {
+//            if let curations = try? await CurationRequest().fetch() {
+//
+//            } else {
+//                writings = []
+//            }
+//            curationsRequestTask = nil
+//        }
+        writingTableView.reloadData()
     }
     
     private func setupNavigationBar() {
@@ -91,6 +148,16 @@ final class WritingListViewController: UIViewController {
         case .commentList:
             navigationItem.title = "댓글 단 글"
         }
+    }
+    
+    // MARK: Actions
+    @objc func writeCurationButtonTapped() {
+        print("DEBUG: TO WRITE")
+    }
+    
+    @objc func readCurationsButtonTapped() {
+        // 큐레이션 리스트 탭바 페이지로 이동
+        tabBarController?.selectedIndex = 1
     }
     
 }
@@ -123,5 +190,14 @@ extension WritingListViewController: UITableViewDataSource {
 
 // MARK: UITableViewDelegate
 extension WritingListViewController: UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let curationVC = PagingCurationViewController(curation: writings[indexPath.row])
+        curationVC.modalPresentationStyle = .overFullScreen
+        curationVC.modalTransitionStyle = .crossDissolve
+        present(curationVC, animated: true)
+        
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
     
 }

--- a/Kindy/Kindy/View Controllers/My Page/WritingListViewController.swift
+++ b/Kindy/Kindy/View Controllers/My Page/WritingListViewController.swift
@@ -176,7 +176,7 @@ extension WritingListViewController: UITableViewDataSource {
         
         imageRequestTask = Task {
             let descriptions = writings[indexPath.row].descriptions
-            if let image = try? await ImageCache.shared.load(descriptions[indexPath.row].image) {
+            if let image = try? await ImageCache.shared.load(descriptions[indexPath.row].image, size: ImageSize.big) {
                 cell.photoImageView.image = image
             } else {
                 cell.photoImageView.image = UIImage()

--- a/Kindy/Kindy/Views/MyPage/MyPageTableViewCell.swift
+++ b/Kindy/Kindy/Views/MyPage/MyPageTableViewCell.swift
@@ -12,6 +12,7 @@ final class MyPageTableViewCell: UITableViewCell {
     // MARK: Properties
     var myPageCellLabel: UILabel = {
         let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 17)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -32,6 +33,13 @@ final class MyPageTableViewCell: UITableViewCell {
         return stackView
     }()
     
+    private let cellSeperator: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(named: "kindyLightGray2")
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
     // MARK: LifeCycle
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .default, reuseIdentifier: reuseIdentifier)
@@ -45,13 +53,20 @@ final class MyPageTableViewCell: UITableViewCell {
     // MARK: Helpers
     private func setupUI() {
         addSubview(myPageCellStackView)
+        addSubview(cellSeperator)
         
         NSLayoutConstraint.activate([
             myPageCellImageView.widthAnchor.constraint(equalToConstant: 14),
             
-            myPageCellStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            myPageCellStackView.topAnchor.constraint(equalTo: topAnchor, constant: 15),
             myPageCellStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: padding16),
-            myPageCellStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -padding16)
+            myPageCellStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -padding16),
+            myPageCellStackView.heightAnchor.constraint(equalToConstant: 25),
+            
+            cellSeperator.topAnchor.constraint(equalTo: myPageCellStackView.bottomAnchor, constant: 15),
+            cellSeperator.leadingAnchor.constraint(equalTo: leadingAnchor, constant: padding16),
+            cellSeperator.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -padding16),
+            cellSeperator.heightAnchor.constraint(equalToConstant: 1),
         ])
     }
     

--- a/Kindy/Kindy/Views/MyPage/NoWritingView.swift
+++ b/Kindy/Kindy/Views/MyPage/NoWritingView.swift
@@ -10,7 +10,7 @@ import UIKit
 final class NoWritingView: UIView {
     
     // MARK: Properties
-    let noWritingLable: UILabel = {
+    let noWritingLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -25,7 +25,7 @@ final class NoWritingView: UIView {
     }()
     
     private lazy var noWritingStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [noWritingLable, noWritingButton])
+        let stackView = UIStackView(arrangedSubviews: [noWritingLabel, noWritingButton])
         stackView.axis = .vertical
         stackView.spacing = 16
         stackView.alignment = .center

--- a/Kindy/Kindy/Views/MyPage/NoWritingView.swift
+++ b/Kindy/Kindy/Views/MyPage/NoWritingView.swift
@@ -1,0 +1,56 @@
+//
+//  NoWritingView.swift
+//  Kindy
+//
+//  Created by WooriJoon on 2022/11/27.
+//
+
+import UIKit
+
+final class NoWritingView: UIView {
+    
+    // MARK: Properties
+    let noWritingLable: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    let noWritingButton: UIButton = {
+        let button = UIButton()
+        button.setTitleColor(UIColor(named: "kindyPrimaryGreen"), for: .normal)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .bold)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    private lazy var noWritingStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [noWritingLable, noWritingButton])
+        stackView.axis = .vertical
+        stackView.spacing = 16
+        stackView.alignment = .center
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    // MARK: LifeCycle
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: Helpers
+    private func setupUI() {
+        addSubview(noWritingStackView)
+        
+        NSLayoutConstraint.activate([
+            noWritingStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            noWritingStackView.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+    
+}

--- a/Kindy/Kindy/Views/MyPage/UserInfoContainerView.swift
+++ b/Kindy/Kindy/Views/MyPage/UserInfoContainerView.swift
@@ -75,7 +75,7 @@ final class UserInfoContainerView: UIView {
         return stackView
     }()
     
-    private let myWritingButton: UIButton = {
+    lazy var myWritingButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "text.book.closed.fill"), for: .normal)
         button.tintColor = .black
@@ -102,7 +102,7 @@ final class UserInfoContainerView: UIView {
         return stackView
     }()
     
-    private let myActivitiesButton: UIButton = {
+    lazy var myActivitiesButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "heart.fill"), for: .normal)
         button.tintColor = .black
@@ -131,8 +131,7 @@ final class UserInfoContainerView: UIView {
     
     // TODO: 추후 커뮤니티 기능이 생기면 첫줄의 주석처리된 스택뷰를 사용하면 됩니다.
     private lazy var infoButtonStackView: UIStackView = {
-//        let stackView = UIStackView(arrangedSubviews: [bookmarkedBookstoreStackView, myWritingStackView, myActivitiesStackView])
-        let stackView = UIStackView(arrangedSubviews: [bookmarkedBookstoreStackView])
+        let stackView = UIStackView(arrangedSubviews: [bookmarkedBookstoreStackView, myWritingStackView, myActivitiesStackView])
         stackView.axis = .horizontal
         stackView.distribution = .fillEqually
         stackView.translatesAutoresizingMaskIntoConstraints = false

--- a/Kindy/Kindy/Views/MyPage/UserInfoContainerView.swift
+++ b/Kindy/Kindy/Views/MyPage/UserInfoContainerView.swift
@@ -129,7 +129,6 @@ final class UserInfoContainerView: UIView {
         return stackView
     }()
     
-    // TODO: 추후 커뮤니티 기능이 생기면 첫줄의 주석처리된 스택뷰를 사용하면 됩니다.
     private lazy var infoButtonStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [bookmarkedBookstoreStackView, myWritingStackView, myActivitiesStackView])
         stackView.axis = .horizontal

--- a/Kindy/Kindy/Views/MyPage/UserInfoContainerView.swift
+++ b/Kindy/Kindy/Views/MyPage/UserInfoContainerView.swift
@@ -48,7 +48,7 @@ final class UserInfoContainerView: UIView {
         return view
     }()
     
-    lazy var bookmarkedBookstoreButton: UIButton = {
+    let bookmarkedBookstoreButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "bookmark.fill"), for: .normal)
         button.tintColor = .black
@@ -75,7 +75,7 @@ final class UserInfoContainerView: UIView {
         return stackView
     }()
     
-    lazy var myWritingButton: UIButton = {
+    let myWritingButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "text.book.closed.fill"), for: .normal)
         button.tintColor = .black
@@ -102,7 +102,7 @@ final class UserInfoContainerView: UIView {
         return stackView
     }()
     
-    lazy var myActivitiesButton: UIButton = {
+    let myActivitiesButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "heart.fill"), for: .normal)
         button.tintColor = .black


### PR DESCRIPTION
# 배경
- 큐레이션이 추가될 예정입니다.
- 큐레이션이 추가되면, 마이페이지의 `userInfoContainerView`에 '내 글' 버튼과 '활동 내역' 버튼이 필요합니다.

# 작업내용
## WritingListViewController
- 마이페이지에서 내 글과 활동 내역을 볼 때 모두 이쪽 뷰로 연결됩니다.
- 어떤 뷰에서 넘어왔는지 체크하기 위해 `PreviousSelectedCell`이라는 `enum`을 추가했습니다.
- `PreviousSelectedCell`의 값을 기준으로 현재 보여줄 뷰를 갈아끼웁니다.

## NoWritingView
- `NoWritingView`는 내 글과 활동 내역 버튼을 눌러 들어갔을때 안에서 조건에 맞는 큐레이션을 테이블 뷰로 보여줘야 하는데,
조건에 맞는 큐레이션이 없을 때 보여줘야 하는 뷰입니다.

## 내 글 버튼
- 내 글 버튼을 눌렀을 때 `WritingListViewController`로 넘어갑니다.
- 해당 버튼을 눌렀을 때 내가 작성한 글을 보여줘야하지만, 현재 내 글의 정보가 없을 때 보여주는 `NoWritingView`가 나타납니다.
- 큐레이션 작성하기 버튼을 누르면 아직 아무 반응이 없지만, 큐레이션 작성 뷰로 넘어갈 예정입니다.

## 활동 내역 버튼
-  활동 내역 버튼을 눌렀을 때 좋아요 한 글, 댓글 단 글의 셀이 나누어져 클릭할 수 있게 구성되어있습니다.
- 각 버튼을 눌렀을때 조건에 맞는 큐레이션을 fetch해와 보여줘야 하지만, 현재 `NoWritingView`를 보여줍니다.
- 큐레이션 보러가기 버튼을 눌렀을 때 큐레이션 탭으로 넘어갑니다.
- 큐레이션 탭으로 넘어갈 때 탭바가 사라지는 이슈가 있어 `viewWillAppear`에 탭바 히든을 꺼주는 코드를 추가해야 할 것 같습니다.

## 그 이외
- 아직 큐레이션을 fetch해오는 기능을 넣지 않아 빈 화면만 나옵니다.
- 각 조건에 맞는 큐레이션을 fetch해오는 기능을 추가해야 합니다.

# 스크린샷
https://user-images.githubusercontent.com/103024858/204489048-4f3dd1d1-9afe-43fb-b8ea-2322202ddb84.mp4

