### PR TITLE
FirestoreRequest 프로토콜 리팩토링을 통해 반복되는 코드 사용을 줄였습니다.

### DIFF
--- a/Kindy/Kindy/Network Controllers/BookstoreRequest.swift
+++ b/Kindy/Kindy/Network Controllers/BookstoreRequest.swift
@@ -14,7 +14,7 @@ struct BookstoreRequest: FirestoreRequest {
 }
  
 extension BookstoreRequest {   
-    // 유저가 가진 서점 id 값으로 북마크된 서점 fetch
+    /// 유저가 북마크한 서점 fetch
     func fetchBookmarkedBookstores() async throws -> [Bookstore] {
         guard UserManager().isLoggedIn() else { return [] }
         

--- a/Kindy/Kindy/Network Controllers/CommentRequest.swift
+++ b/Kindy/Kindy/Network Controllers/CommentRequest.swift
@@ -11,6 +11,7 @@ import FirebaseFirestoreSwift
 
 struct CommentRequest: FirestoreRequest {
     typealias Response = Comment
+    let parentCollectionPath = CollectionPath.curations
     let collectionPath = CollectionPath.comments
 }
 
@@ -18,22 +19,21 @@ extension CommentRequest {
     /// 댓글 추가
     func add(curationID: String, userID: String ,content: String, count: Int) async throws {
         let comment = Comment(id: UUID().uuidString, userID: userID, content: content, createdAt: Date())
-        try await db.collection(CollectionPath.curations).document(curationID).collection(collectionPath).document(comment.id)
-            .setData(
-                [
-                    "id" : comment.id,
-                    "userID" : comment.userID,
-                    "content" : comment.content,
-                    "createdAt" : comment.createdAt
-                ]
-            )
+        try await subdocumentReference(curationID, comment.id).setData(
+            [
+                "id" : comment.id,
+                "userID" : comment.userID,
+                "content" : comment.content,
+                "createdAt" : comment.createdAt
+            ]
+        )
         
         try await CurationRequest().updateCommentCount(curationID: curationID, count: count)
     }
     
     /// 댓글 삭제
     func delete(curationID: String, commentID: String, count: Int) async throws {
-        try await db.collection(CollectionPath.curations).document(curationID).collection(collectionPath).document(commentID).delete()
+        try await subdocumentReference(curationID, commentID).delete()
         try await CurationRequest().updateCommentCount(curationID: curationID, count: count)
     }
 }
@@ -41,14 +41,14 @@ extension CommentRequest {
 extension CommentRequest {
     /// 처음에 모든 댓글 불러오는 함수
     func fetch(with documentID: String) async throws -> [Comment] {
-        let querySnapshot = try await db.collection(CollectionPath.curations).document(documentID).collection(collectionPath).getDocuments()
+        let querySnapshot = try await subcollectionReference(documentID).getDocuments()
         let responses = try querySnapshot.documents.map { try $0.data(as: Comment.self) }
         return responses
     }
     
     ///  댓글의 바뀐 부분만 불러오는 함수
     func update(curationID: String, completion: @escaping (QuerySnapshot?, Error?) -> Void) -> ListenerRegistration {
-        return db.collection(CollectionPath.curations).document(curationID).collection(collectionPath).addSnapshotListener { querySnapshot, error in
+        return subcollectionReference(curationID).addSnapshotListener { querySnapshot, error in
             completion(querySnapshot,error)
         }
     }

--- a/Kindy/Kindy/Network Controllers/CurationRequest.swift
+++ b/Kindy/Kindy/Network Controllers/CurationRequest.swift
@@ -18,14 +18,12 @@ struct CurationRequest: FirestoreRequest {
 extension CurationRequest {
     /// 큐레이션의 likes 업데이트
     func updateLike(curationID: String, likes: [String]) async throws {
-        let document = db.collection(collectionPath).document(curationID)
-        try await document.updateData(["likes" : likes])
+        try await documentReference(curationID).updateData(["likes" : likes])
     }
     
     /// 큐레이션 댓글 수 업데이트
     func updateCommentCount(curationID: String, count: Int) async throws {
-        let document = db.collection(collectionPath).document(curationID)
-        try await document.updateData(["commentCount" : count])
+        try await documentReference(curationID).updateData(["commentCount" : count])
     }
 }
 

--- a/Kindy/Kindy/Network Controllers/UserManager.swift
+++ b/Kindy/Kindy/Network Controllers/UserManager.swift
@@ -6,9 +6,9 @@
 //
 
 import Foundation
-import FirebaseFirestoreSwift
 import FirebaseAuth
 import FirebaseFirestore
+import FirebaseFirestoreSwift
 
 struct UserManager: FirestoreRequest {
     typealias Response = User
@@ -24,12 +24,12 @@ extension UserManager {
     
     /// 현재 로그인되어 있는 정보로 유저 데이터 fetch
     func fetchCurrentUser() async throws -> User {
-        return try await db.collection(collectionPath).document(Auth.auth().currentUser?.uid ?? "").getDocument(as: User.self)
+        return try await documentReference(Auth.auth().currentUser?.uid ?? "").getDocument(as: User.self)
     }
     
     /// 북마크 데이터 변경
     func updateBookmark(email: String, provider: String, bookmarkedBookstores: [String]) async throws {
-        let querySnapshot = try await db.collection(collectionPath).whereField("email", isEqualTo: email).whereField("provider", isEqualTo: provider).getDocuments()
+        let querySnapshot = try await collectionReference.whereField("email", isEqualTo: email).whereField("provider", isEqualTo: provider).getDocuments()
         let document = querySnapshot.documents.first
         try await document?.reference.updateData(["bookmarkedBookstores" : bookmarkedBookstores])
     }
@@ -50,7 +50,7 @@ extension UserManager {
     /// 이미 가입한 유저인지 확인
     func isExistingUser(_ email: String?, _ provider: String) async throws -> Bool {
         if let email = email {
-            return try await !db.collection(collectionPath).whereField("email", isEqualTo: email).whereField("provider", isEqualTo: provider).getDocuments().documents.map{ $0.documentID }.isEmpty
+            return try await !collectionReference.whereField("email", isEqualTo: email).whereField("provider", isEqualTo: provider).getDocuments().documents.map{ $0.documentID }.isEmpty
         } else {
             return false
         }
@@ -60,7 +60,7 @@ extension UserManager {
     func delete() {
         let auth = Auth.auth().currentUser
         
-        db.collection(collectionPath).document(auth?.uid ?? "al").delete() { _ in
+        documentReference(auth?.uid ?? "al").delete() { _ in
             auth?.delete()
         }
     }
@@ -70,38 +70,36 @@ extension UserManager {
 extension UserManager {
     /// 닉네임 중복확인
     func isExistingNickname(_ nickName: String) async throws -> Bool {
-        let nickNames = try await db.collection(collectionPath).getDocuments().documents.map{ $0.data() }.filter{ String(describing: $0["nickName"]!) == nickName }
+        let nickNames = try await collectionReference.getDocuments().documents.map{ $0.data() }.filter{ String(describing: $0["nickName"]!) == nickName }
         return !nickNames.isEmpty
     }
 
     /// 닉네임 수정
     func editNickname(_ newNickname: String) {
-        let user = db.collection(collectionPath).document(Auth.auth().currentUser?.uid ?? "")
-        user.updateData(["nickName": newNickname])
+        documentReference(Auth.auth().currentUser?.uid ?? "").updateData(["nickName": newNickname])
     }
 }
 
-/// 마이페이지에서 사용하는 CurationRequest
+// MARK: 마이페이지에서 사용하는 CurationRequest
 extension UserManager {
-    
-    // 내가 작성한 큐레이션
+    /// 내가 작성한 큐레이션 fetch
     func fetchMyCurations(userID: String) async throws -> [Curation] {
         let querySnapShot = try await db.collection(CollectionPath.curations).whereField("userID", isEqualTo: userID).getDocuments()
         let document = try querySnapShot.documents.map { try $0.data(as: Curation.self) }
         return document.reversed()
     }
     
-    // 좋아요 한 큐레이션
+    /// 좋아요 한 큐레이션 fetch
     func fetchLikedCurations(userID: String) async throws -> [Curation] {
         let querySnapshot = try await db.collection(CollectionPath.curations).whereField("likes", arrayContains: userID).getDocuments()
         let document = try querySnapshot.documents.map { try $0.data(as: Curation.self) }
         return document.reversed()
     }
     
-    // 댓글 단 큐레이션
+    /// 댓글 단 큐레이션 fetch
     func fetchCommentedCurations(userID: String) async throws -> [Curation] {
         // 현재 유저의 document 데이터를 가져와서
-        let documentSnapshot = try await db.collection(CollectionPath.users).document(userID).getDocument()
+        let documentSnapshot = try await documentReference(userID).getDocument()
         let user = try documentSnapshot.data(as: User.self)
         var commentedCurations: [Curation] = []
         
@@ -128,7 +126,7 @@ extension UserManager {
     
     // 유저의 댓글 단 큐레이션 필드에 큐레이션 id 추가
     func addCommentedCuration(userID: String, curationID: String) throws {
-        let field = db.collection(CollectionPath.users).document(userID)
+        let field = db.collection(collectionPath).document(userID)
         // arrayUnion: 현재 댓글을 작성한 큐레이션의 id가 유저의 필드에 이미 있다면 중복으로 업데이트하지 않음
         field.updateData(["commentedCurations": FieldValue.arrayUnion([curationID])])
     }
@@ -140,7 +138,7 @@ extension UserManager {
         
         switch myComments.count {
         case 1:
-            let field = db.collection(CollectionPath.users).document(userID)
+            let field = db.collection(collectionPath).document(userID)
             try await field.updateData(["commentedCurations": FieldValue.arrayRemove([curationID])])
             
         default:
@@ -162,7 +160,7 @@ extension UserManager {
             guard !repeatedUserID.contains(currentUserID) else { continue }
             
             repeatedUserID.append(currentUserID)
-            let field = db.collection(CollectionPath.users).document(currentUserID)
+            let field = db.collection(collectionPath).document(currentUserID)
             try await field.updateData(["commentedCurations": FieldValue.arrayRemove([curationID])])
         }
     }

--- a/Kindy/Kindy/Protocols/FirestoreRequest.swift
+++ b/Kindy/Kindy/Protocols/FirestoreRequest.swift
@@ -13,33 +13,68 @@ import FirebaseAuth
 protocol FirestoreRequest where Response: Codable & Identifiable {
     associatedtype Response
     
+    var parentCollectionPath: String { get }
     var collectionPath: String { get }
 }
 
 extension FirestoreRequest {
+    /// Firestore db에 대한 참조
     var db: Firestore { Firestore.firestore() }
+}
+
+// MARK: Collection
+extension FirestoreRequest {
+    /// Firestore collection에 대한 참조
+    var collectionReference: CollectionReference { db.collection(collectionPath) }
+    
+    /// Firestore document에 대한 참조
+    func documentReference(_ documentID: String) -> DocumentReference {
+        return collectionReference.document(documentID)
+    }
+}
+
+// MARK: Subcollection
+extension FirestoreRequest {
+    /// Subcollection에 접근하기 위한  parent collection path
+    var parentCollectionPath: String { "" }
+    
+    var parentCollectionReference: CollectionReference { db.collection(parentCollectionPath) }
+    
+    /// Firestore Subcollection에 대한 참조
+    func subcollectionReference(_ parentDocumentID: String) -> CollectionReference {
+        return parentCollectionReference.document(parentDocumentID).collection(collectionPath)
+    }
+    
+    /// Firestore Subcollection의 document에 대한 참조
+    func subdocumentReference(_ parentDocumentID: String, _ childDocumentID: String) -> DocumentReference {
+        return subcollectionReference(parentDocumentID).document(childDocumentID)
+    }
 }
 
 extension FirestoreRequest {
     /// 모든 도큐먼트 fetch
     func fetch() async throws -> [Response] {
-        let querySnapshot = try await db.collection(collectionPath).getDocuments()
+        let querySnapshot = try await collectionReference.getDocuments()
         let responses = try querySnapshot.documents.map { try $0.data(as: Response.self) }
         return responses
     }
     
     /// 도큐먼트 id로 특정 도큐먼트 fetch
     func fetch(with documentID: String) async throws -> Response {
-        return try await db.collection(collectionPath).document(documentID).getDocument(as: Response.self)
+        return try await documentReference(documentID).getDocument(as: Response.self)
     }
     
     /// 도큐먼트 추가
     func add(_ document: Response) throws {
-        try db.collection(collectionPath).document(document.id as? String ?? UUID().uuidString).setData(from: document)
+        try documentReference(document.id as? String ?? UUID().uuidString).setData(from: document)
     }
     
     /// id로 특정 도큐먼트 삭제
     func delete(_ documentID: String) async throws {
-        try await db.collection(collectionPath).document(documentID).delete()
+        try await documentReference(documentID).delete()
+        
+        if Response.self == Curation.self {
+            try await UserManager().deleteAllCommentedCuration(curationID: documentID)
+        }
     }
 }


### PR DESCRIPTION
# 배경
- 각각의 Request에서 불필요하게 반복되는 코드들이 많았습니다.
# 작업 내용
- 가독성을 해치던 반복되는 코드를 줄였습니다.
- 반복되었던 코드: CollectionReference, DocumentReference를 구하는 코드
### 개선점
- before: db.collection(collectionPath).document(documentID)의 형태로 DocumentReference를 얻었습니다.
- after: documentReference(documentID)의 형태로 DocumentReference를 얻을 수 있습니다.
#### 가장 큰 문제는 댓글부분이었었습니다.
- before: db.collection(collectionPath).document(documentID).collection(collectionPath).document(documentID)의 형태
- after: subdocumentReference(documentID, documentID)의 형태로 개선

CollectionReference도 사용법은 동일합니다.
### 참고
- UserManager는 나중에 리팩토링하겠습니다.
# 스크린샷
x