### PR TITLE
큐레이션 로딩 뷰 삭제, 댓글 수 업데이트 로직 변경, 이미지 불러오는 방식 변경

### DIFF
--- a/Kindy/Kindy/Extensions/UIView+.swift
+++ b/Kindy/Kindy/Extensions/UIView+.swift
@@ -17,3 +17,15 @@ extension UIView {
         UIScreen.main.bounds.height
     }
 }
+
+extension UIView {
+    func gradientView(bounds: CGRect, colors: [CGColor]) -> CAGradientLayer {
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.frame = bounds
+        gradientLayer.colors = colors
+
+        gradientLayer.startPoint = CGPoint(x: 0.5, y: 0.0)
+        gradientLayer.endPoint = CGPoint(x: 0.5, y: 1.0)
+        return gradientLayer
+    }
+}

--- a/Kindy/Kindy/Network Controllers/CommentRequest.swift
+++ b/Kindy/Kindy/Network Controllers/CommentRequest.swift
@@ -1,7 +1,6 @@
-import Foundation
-
 import FirebaseFirestore
 import FirebaseFirestoreSwift
+import Foundation
 
 struct CommentRequest: FirestoreRequest {
     typealias Response = Comment
@@ -12,12 +11,7 @@ struct CommentRequest: FirestoreRequest {
 extension CommentRequest {
     /// 댓글 추가
     func add(curationID: String, userID: String, content: String, count: Int) async throws {
-        let comment = Comment(
-            id: UUID().uuidString,
-            userID: userID,
-            content: content,
-            createdAt: Date()
-        )
+        let comment = Comment(id: UUID().uuidString, userID: userID, content: content, createdAt: Date())
         try await subdocumentReference(curationID, comment.id).setData(
             [
                 "id": comment.id,
@@ -27,13 +21,13 @@ extension CommentRequest {
             ]
         )
 
-        try await CurationRequest().updateCommentCount(curationID: curationID, count: count)
+        try await CurationRequest().updateCommentCount(curationID: curationID, plus: true)
     }
 
     /// 댓글 삭제
     func delete(curationID: String, commentID: String, count: Int) async throws {
         try await subdocumentReference(curationID, commentID).delete()
-        try await CurationRequest().updateCommentCount(curationID: curationID, count: count)
+        try await CurationRequest().updateCommentCount(curationID: curationID, plus: false)
     }
 }
 
@@ -43,15 +37,5 @@ extension CommentRequest {
         let querySnapshot = try await subcollectionReference(documentID).getDocuments()
         let responses = try querySnapshot.documents.map { try $0.data(as: Comment.self) }
         return responses
-    }
-
-    ///  댓글의 바뀐 부분만 불러오는 함수
-    func update(
-        curationID: String,
-        completion: @escaping (QuerySnapshot?, Error?) -> Void
-    ) -> ListenerRegistration {
-        subcollectionReference(curationID).addSnapshotListener { querySnapshot, error in
-            completion(querySnapshot, error)
-        }
     }
 }

--- a/Kindy/Kindy/Network Controllers/CurationRequest.swift
+++ b/Kindy/Kindy/Network Controllers/CurationRequest.swift
@@ -2,6 +2,7 @@ import UIKit
 
 import FirebaseFirestoreSwift
 import FirebaseStorage
+import FirebaseFirestore
 
 struct CurationRequest: FirestoreRequest {
     typealias Response = Curation
@@ -15,7 +16,16 @@ extension CurationRequest {
     }
 
     /// 큐레이션 댓글 수 업데이트
-    func updateCommentCount(curationID: String, count: Int) async throws {
+    func updateCommentCount(curationID: String, plus: Bool) async throws {
+        if plus {
+            try await documentReference(curationID).updateData(["commentCount": FieldValue.increment(Int64(1))])
+        } else {
+            try await documentReference(curationID).updateData(["commentCount": FieldValue.increment(Int64(-1))])
+        }
+    }
+
+    /// 큐레이션에 저장된 댓글 수와, 실제 댓글 수를 같게 하는 함수
+    func equalizedCommentCount(curationID: String, count: Int) async throws {
         try await documentReference(curationID).updateData(["commentCount": count])
     }
 }

--- a/Kindy/Kindy/View Controllers/Curation List/CurationListViewController.swift
+++ b/Kindy/Kindy/View Controllers/Curation List/CurationListViewController.swift
@@ -192,10 +192,7 @@ final class CurationListViewController: UIViewController {
 // MARK: - DataSource
 
 extension CurationListViewController: UITableViewDataSource {
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-
-        return curations.count
-    }
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int { curations.count }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: CurationListCell.identifier, for: indexPath) as? CurationListCell else { return UITableViewCell() }
@@ -231,7 +228,7 @@ extension CurationListViewController: UITableViewDataSource {
 
 extension CurationListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let curationVC = PagingCurationViewController(curation: curations[indexPath.row])
+        let curationVC = PagingCurationViewController(curation: curations[indexPath.row], mainImage: curationImage)
         curationVC.modalPresentationStyle = .fullScreen
         curationVC.modalTransitionStyle = .crossDissolve
 

--- a/Kindy/Kindy/View Controllers/Curation/Create/CurationCreateViewController.swift
+++ b/Kindy/Kindy/View Controllers/Curation/Create/CurationCreateViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import PhotosUI
 
+// swiftlint:disable type_name
 final class CurationCreateViewController: UIViewController {
 
     var curationImagesTask: Task<Void, Never>?

--- a/Kindy/Kindy/View Controllers/Curation/CurationViewController.swift
+++ b/Kindy/Kindy/View Controllers/Curation/CurationViewController.swift
@@ -136,11 +136,11 @@ final class CurationViewController: UIViewController {
         return view
     }()
 
-    private lazy var bottomView: UIView = {
+    private lazy var bottomView: CurationButtonStackView = {
         let view = CurationButtonStackView(frame: .zero, curation: curation)
-        guard let replyView = view.replyView as? CurationButtonItemView else { return UIView()}
+        let replyView = view.replyView
         replyView.delegate = self
-        guard let settingView = view.settingView as? CurationButtonItemView else { return UIView() }
+        let settingView = view.settingView
         settingView.menuDelegate = self
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
@@ -225,17 +225,16 @@ final class CurationViewController: UIViewController {
         }
 
         userNameTask = Task {
-            updatedComments.sort(by: { first, second in
+            updatedComments.sort { first, second in
                 first.createdAt < second.createdAt
-            })
+            }
 
             comments = try? await updatedComments.concurrentMap { comment in
                 if comment.userNickname == nil {
                     var newComment = comment
                     newComment.userNickname = try? await self.userManager.fetch(with: comment.userID).nickName
                     return newComment
-                }
-                else { return comment }
+                } else { return comment }
             }
 
             replyCount = comments?.count ?? 0
@@ -493,12 +492,10 @@ extension CurationViewController: UIGestureRecognizerDelegate {
 
 extension CurationViewController {
     func updatedCounts() {
-        guard let stackView = bottomView as? CurationButtonStackView else { return }
-
-        guard let replyView = stackView.replyView as? CurationButtonItemView else { return }
+        let replyView = bottomView.replyView
         replyView.countLabel.text = String(replyCount)
 
-        guard let likeView = stackView.heartView as? CurationButtonItemView else { return }
+        let likeView = bottomView.heartView
         likeView.countLabel.text = String(likeCount)
     }
 }
@@ -549,7 +546,7 @@ extension CurationViewController: ShowingMenu, Reportable {
 
                         try? self.curationManager.deleteImage(url: self.curation.mainImage)
 
-                        let _ = try? await self.curation.descriptions.concurrentMap { description in
+                        _ = try? await self.curation.descriptions.concurrentMap { description in
                             try self.curationManager.deleteImage(url: description.image ?? "")
                         }
 

--- a/Kindy/Kindy/View Controllers/Curation/CurationViewController.swift
+++ b/Kindy/Kindy/View Controllers/Curation/CurationViewController.swift
@@ -288,14 +288,13 @@ extension CurationViewController: UICollectionViewDataSource {
         //            return cell
         //        } else
         // --- 서점 스토어셀은 추후에 추가
-        if indexPath.section == 0 {
-            if indexPath.item == 0 {
-                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CurationTextCell.identifier, for: indexPath) as? CurationTextCell else { return UICollectionViewCell() }
-                cell.headConfigure(data: curation)
+        switch (indexPath.section, indexPath.item) {
+        case (0, 0):
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CurationTextCell.identifier, for: indexPath) as? CurationTextCell else { return UICollectionViewCell() }
+            cell.headConfigure(data: curation)
+            return cell
 
-                return cell
-            }
-
+        case (0, 1...):
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CurationDetailCell.identifier, for: indexPath) as? CurationDetailCell else { return UICollectionViewCell() }
 
             if indexPath.item == cellCount {
@@ -319,21 +318,23 @@ extension CurationViewController: UICollectionViewDataSource {
             cell.configure(description: curation.descriptions[indexPath.item - 1].content ?? "")
 
             return cell
-        }
 
-        if indexPath.item != replyCount {
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CurationCommentCell.identifier, for: indexPath) as? CurationCommentCell else { return UICollectionViewCell() }
-
-            guard let comments else { return UICollectionViewCell()}
+        case (1, 0..<replyCount):
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CurationCommentCell.identifier, for: indexPath) as? CurationCommentCell,
+                  let comments = comments else { return UICollectionViewCell() }
             cell.configure(data: comments[indexPath.item])
 
             return cell
-        } else {
+
+        case (1, replyCount):
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CurationCommentTextFieldCell.identifier, for: indexPath) as? CurationCommentTextFieldCell else { return UICollectionViewCell() }
             cell.bottomTextFieldView.delegate = self
             cell.delegate = self
 
             return cell
+
+        default:
+            return UICollectionViewCell()
         }
     }
 }

--- a/Kindy/Kindy/View Controllers/Curation/CurationViewController.swift
+++ b/Kindy/Kindy/View Controllers/Curation/CurationViewController.swift
@@ -86,20 +86,21 @@ final class CurationViewController: UIViewController {
             }
 
             snapshot.documentChanges.forEach { diff in
-                if (diff.type == .added) {
+                switch diff.type {
+                case .added:
                     try? self.updatedComments.append(diff.document.data(as: Comment.self))
                     self.serverReplyCount = self.updatedComments.count
-                }
-                if (diff.type == .modified) {
-                    print("Modified : \(diff.document.data())")
-                }
-                if (diff.type == .removed) {
+
+                case .removed:
                     guard let removedComment = try? diff.document.data(as: Comment.self) else { return }
 
                     self.updatedComments = self.updatedComments.filter { comment in
                         comment.id != removedComment.id
                     }
                     self.serverReplyCount = self.updatedComments.count
+
+                default:
+                    return
                 }
             }
 
@@ -117,7 +118,7 @@ final class CurationViewController: UIViewController {
         self.curation = curation
         self.images = images
         super.init(nibName: nil, bundle: nil)
-        print(listener)
+        _ = listener
     }
 
     required init?(coder: NSCoder) {

--- a/Kindy/Kindy/View Controllers/Curation/PagingCurationViewController.swift
+++ b/Kindy/Kindy/View Controllers/Curation/PagingCurationViewController.swift
@@ -98,12 +98,7 @@ final class PagingCurationViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
-        UIView.animate(withDuration: 0.3, animations: {
-            self.setNeedsStatusBarAppearanceUpdate()
-        })
-
-        createGradient(view: headerView, startAlpha: 0.6)
+//        self.present(bottomVC, animated: false)
         changeGradientLayer(view: headerView)
 
         self.imageRequestTask = Task {

--- a/Kindy/Kindy/View Controllers/Home Detail/NearbyViewController.swift
+++ b/Kindy/Kindy/View Controllers/Home Detail/NearbyViewController.swift
@@ -111,7 +111,7 @@ final class NearbyViewController: UIViewController, UISearchResultsUpdating {
 }
 
 // MARK: - DataSource
-
+// swiftlint:disable empty_count
 extension NearbyViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         filteredItems.count == 0 ? tableView.setEmptyView(text: "현재 계신 곳 주변에 독립서점 정보가 없어요") : tableView.restore()

--- a/Kindy/Kindy/View Controllers/Home Detail/RegionViewController.swift
+++ b/Kindy/Kindy/View Controllers/Home Detail/RegionViewController.swift
@@ -139,7 +139,7 @@ final class RegionViewController: UIViewController, UISearchResultsUpdating {
 }
 
 // MARK: - 데이터 소스
-
+// swiftlint:disable empty_count
 extension RegionViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         filteredItems.count == 0 ? tableView.setEmptyView(text: "찾으시는 서점이 없으신가요?") : tableView.restore()

--- a/Kindy/Kindy/View Controllers/My Page/EditNicknameViewController.swift
+++ b/Kindy/Kindy/View Controllers/My Page/EditNicknameViewController.swift
@@ -84,7 +84,8 @@ extension EditNicknameViewController: UITextFieldDelegate {
         let previousNSString: NSString = (textField.text ?? "") as NSString
         let currentNSString: NSString = previousNSString.replacingCharacters(in: range, with: string) as NSString
         let currentTextFieldText: String = currentNSString as String
-
+        
+        // swiftlint:disable empty_count
         // 텍스트 필드가 비어져있으면 완료 버튼 비활성화
         if currentTextFieldText.count == 0 {
             deactivateEditButton()

--- a/Kindy/Kindy/View Controllers/Search/SearchViewController.swift
+++ b/Kindy/Kindy/View Controllers/Search/SearchViewController.swift
@@ -203,7 +203,7 @@ extension SearchViewController: UITableViewDataSource {
         default: return UITableViewCell()
         }
     }
-
+    // swiftlint:disable empty_count
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         return filteredItems.count == 0 ? nil : "총 \(filteredItems.count)개"
     }

--- a/Kindy/Kindy/Views/Bookstore Detail/DetailBookstoreView.swift
+++ b/Kindy/Kindy/Views/Bookstore Detail/DetailBookstoreView.swift
@@ -8,6 +8,8 @@
 import UIKit
 import MapKit
 
+// swiftlint:disable type_body_length
+
 // FIXME: 주석처리한 부분과 기타 디테일을 수정해주세용
 final class DetailBookstoreView: UIView {
 

--- a/Kindy/Kindy/Views/Curation/CurationButtonItem.swift
+++ b/Kindy/Kindy/Views/Curation/CurationButtonItem.swift
@@ -15,7 +15,6 @@ protocol ShowingMenu: AnyObject {
 }
 
 final class CurationButtonItemView: UIView {
-
     enum Views {
         case heart
         case comment
@@ -39,12 +38,10 @@ final class CurationButtonItemView: UIView {
 
     private lazy var heartCount: Int = curation?.likes.count ?? 0
     private var commentCount: Int {
-        get {
-            if let count = curation?.commentCount {
-                return count
-            } else {
-                return 0
-            }
+        if let count = curation?.commentCount {
+            return count
+        } else {
+            return 0
         }
     }
 
@@ -164,7 +161,7 @@ final class CurationButtonItemView: UIView {
     }
 }
 
-private extension CurationButtonItemView {
+extension CurationButtonItemView {
     @objc func customAction() {
         if isLoggedIn || UserManager().isLoggedIn() {
             switch view {

--- a/Kindy/Kindy/Views/Curation/CurationButtonStackView.swift
+++ b/Kindy/Kindy/Views/Curation/CurationButtonStackView.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 final class CurationButtonStackView: UIView {
-
     private let curation: Curation
 
     private let stackView: UIStackView = {
@@ -20,7 +19,7 @@ final class CurationButtonStackView: UIView {
         return view
     }()
 
-    private lazy var heartView: UIView = {
+    private(set) lazy var heartView: UIView = {
         let view = CurationButtonItemView(frame: .zero, curation: curation, viewName: .heart)
         return view
     }()

--- a/Kindy/Kindy/Views/Curation/CurationButtonStackView.swift
+++ b/Kindy/Kindy/Views/Curation/CurationButtonStackView.swift
@@ -19,17 +19,17 @@ final class CurationButtonStackView: UIView {
         return view
     }()
 
-    private(set) lazy var heartView: UIView = {
+    private(set) lazy var heartView: CurationButtonItemView = {
         let view = CurationButtonItemView(frame: .zero, curation: curation, viewName: .heart)
         return view
     }()
 
-    private(set) lazy var replyView: UIView = {
+    private(set) lazy var replyView: CurationButtonItemView = {
         let view = CurationButtonItemView(frame: .zero, curation: curation, viewName: .comment)
         return view
     }()
 
-    private(set) lazy var settingView: UIView = {
+    private(set) lazy var settingView: CurationButtonItemView = {
         let view = CurationButtonItemView(frame: .zero, viewName: .setting)
         view.translatesAutoresizingMaskIntoConstraints = false
         return view

--- a/Kindy/Kindy/Views/Curation/CurationCommentCell.swift
+++ b/Kindy/Kindy/Views/Curation/CurationCommentCell.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 final class CurationCommentCell: UICollectionViewCell {
-
     private let stackView: UIStackView = {
         let view = UIStackView()
         view.axis = .vertical
@@ -131,6 +130,7 @@ final class CurationCommentCell: UICollectionViewCell {
     func configure(data: Comment) {
         descriptionLabel.text = data.content
         dateLabel.text = dateToString(data.createdAt)
+        userLabel.text = data.userNickname
     }
 
     @objc func presentReportView() {

--- a/Kindy/Kindy/Views/Curation/CurationDetailCell.swift
+++ b/Kindy/Kindy/Views/Curation/CurationDetailCell.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 final class CurationDetailCell: UICollectionViewCell {
-
     private lazy var lineView: UIView = {
         let view = UIView()
         view.backgroundColor = .kindyLightGray
@@ -25,7 +24,7 @@ final class CurationDetailCell: UICollectionViewCell {
         return view
     }()
 
-    private lazy var imageView: UIImageView = {
+    private(set) lazy var imageView: UIImageView = {
         let view = UIImageView()
         view.contentMode = .scaleAspectFill
         view.clipsToBounds = true
@@ -44,6 +43,12 @@ final class CurationDetailCell: UICollectionViewCell {
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        imageView.image = nil
+        descriptionLabel.text = nil
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -78,9 +83,8 @@ final class CurationDetailCell: UICollectionViewCell {
         ])
     }
 
-    func configure(description: Description, image: UIImage) {
-        imageView.image = image
-        descriptionLabel.text = description.content
+    func configure(description: String) {
+        descriptionLabel.text = description
     }
 
     func addLineView() {

--- a/Kindy/Kindy/Views/Curation/CurationDetailCell.swift
+++ b/Kindy/Kindy/Views/Curation/CurationDetailCell.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 final class CurationDetailCell: UICollectionViewCell {
+    var url: String?
+
     private lazy var lineView: UIView = {
         let view = UIView()
         view.backgroundColor = .kindyLightGray
@@ -46,6 +48,7 @@ final class CurationDetailCell: UICollectionViewCell {
 
     override func prepareForReuse() {
         super.prepareForReuse()
+        url = nil
         imageView.image = nil
         descriptionLabel.text = nil
     }

--- a/Kindy/Kindy/Views/Curation/CurationHeaderView.swift
+++ b/Kindy/Kindy/Views/Curation/CurationHeaderView.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 final class CurationHeaderView: UIView {
+    private var isFirstViewing: Bool = true
 
     private(set) lazy var imageView: UIImageView = {
         let view = UIImageView()
@@ -42,11 +43,16 @@ final class CurationHeaderView: UIView {
         self.configureData(curationData: curation)
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        isFirstViewing ? createGradient() : ()
+    }
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func configureUI() {
+    private func configureUI(){
         self.addSubview(imageView)
         self.addSubview(titleLabel)
         self.addSubview(subtitleLabel)
@@ -70,5 +76,13 @@ final class CurationHeaderView: UIView {
     private func configureData(curationData: Curation) {
         self.titleLabel.text = curationData.title
         self.subtitleLabel.text = curationData.subTitle
+    }
+
+    private func createGradient() {
+        isFirstViewing = false
+        let gradientSize = CGRect(x: 0, y: 0, width: bounds.width, height: bounds.height)
+        let gradient = gradientView(bounds: gradientSize, colors: [UIColor(red: 0, green: 0, blue: 0, alpha: 0.5).cgColor, UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor])
+
+        layer.insertSublayer(gradient, at: 1)
     }
 }


### PR DESCRIPTION
> 3/15 커밋 내용 댓글에 추가하였씀니다!

# 배경

- 애니메이션을 도입하기 위해 로딩 뷰를 삭제할  필요가 있었고, 기존에 로딩 뷰에서 불러오던 이미지를 셀 생성시 불러오도록 변경할 필요가 있었습니다. 
- 작업 중 댓글,좋아요 수 업데이트 하는 로직의 문제를 발견하여 수정하였습니다
- 댓글 fetch 해오는 부분의 속도의 개선이 필요했습니다.
- 기존 리스너(파이어베이스 문서 변경사항을 추적하는 친구)의 오류가 있어 수정하였습니다.
- 강제 언래핑 로직을 대폭 줄였고, 불필요한 guard let ~~ as? ~~ 로 타입을 확인하는 로직들도 줄였습니다.

# 작업 내용

- 기존 로딩 뷰를 삭제하였습니다.
    - 삭제  후, 후처리
    - 기존에 로딩 뷰가 보여지는 시간에 불러오던 이미지를 셀 생성하면서 불러오는 방식으로 변경하였습니다.
    - 그로인해 PagingCurationVC에서 CurationVC를 `present` 하는 로직을 대폭 수정하였습니다.
        - `viewDidAppear`에서 그라데이션을 적용하는 부분을 UIView 내부에서 하도록 변경하였습니다.
            - 이렇게 한 이유는, 뷰가 present 후에 그라데이션이 적용되어 느리고 어색해보였기 때문입니다.
        - UIView+에 그라데이션을 추가하는 함수를 추가하였고, 그라데이션을 적용할 뷰 내부에 적용하기위해 `layoutSubviews` 함수 내부에서 그라데이션 적용 함수를 호출하였습니다. (이렇게 하지 않으면 frame 사이즈를 계산하지 못하여 적용이 x)

- 댓글 수(and 좋아요 수) 업데이트 로직을 변경하였습니다.
    - 기존에 하나 추가시 1을 더하고 서버에 적용하고 삭제시 1을 빼고 서버에 적용하던 부분이 오류가 많아서 수정하였습니다.
    - 서버에 있는 댓글 수와, 클라이언트가 들고있는 댓글 수를 비교하여 서버에 데이터에 맞추었습니다.

- 댓글 fetch 하는 부분의 속도를 개선하였습니다.
    - 기존의 댓글을 불러오고 닉네임을 `userID` 를 확인하여 fetch 해오는 로직의 속도가 느려 화면에 바로바로 안 보여주던 부분을 개선하였습니다.
    - `concurrentMap`을 활용하여 동시에 fetch하는 식으로 변경하였고, 실제로 적용 전보다 바로 화면에 댓글이 보여 눈에 띄게 개선되었습니다. (예전거 영상이 없는데 ㄹㅇ 차이납니다 나만 느끼는건지는 모르겠는디 ㅋㅌㅋ)

- 리스너의 로직을 변경하였습니다.
    - 기존에는 함수로 리스너를 반환하여 `completion`에 작성하던 로직을 CurationVC 내부 지연 저장 속성 프로퍼티로 변경하였습니다.
    - 차이는 `private`로 접근을 제한하였고 한 번만 초기화 되는 정도임니다.  (추가로 얘를 활성화하려면 `print(listner)`로 한 번 불러와서 초기화 시키는데 다른 좋은 방법이 있다면 알려주십쇼,, 먼가 좀 그렇네여 ㅋㅌ)
    - 리스너 오류로는, 파이어베이스의 문서 변경을 추적하기 때문에 만약 댓글이 삭제되었다면 얘 내부 로직이 실행되어서 코멘트 개수가 줄어들었습니다. 그로 인해 컬렉션 뷰 셀을 생성할 때 `count`가 같지 않아 앱이 터지는 오류가 있었습니다.. (간단히, 하나의 `comments` 만 사용하여서 발생한 문제)
        - 그래서 `updatedComments`라는 `comment` 배열을 추가로 만들어서 서버에 업데이트 되는 내용을 요기에 적용 후 유저가 새로고침이나 댓글 생성, 삭제시에만 얘를 `comments`에 대입하여 오류를 해결하였습니다.

- 마지막으로 `try!, as!` 이런 강제언래핑과 불필요하게 타입을 확인하는 `guard let ~~ as ~~`로직을 줄였습니다,
    - 예로 `CurationHeaderView`를 VC에서 부를 때 `UIView`로 타입을 명시하였는데 멍청했슴다,, 그냥 `CurationHeaderView`로 타입을 명시하면 나중에 `HeaderView` 내부를 수정할 때 불필요하게 `guard let headerView = headerView as? CurationHeaderView else { return }` 하지 않아도 되는 부분이라 이런 부분을 삭제하였습니다. 
        
# 스크린샷

https://user-images.githubusercontent.com/66784492/216523180-eeabbd92-30b9-449f-af0b-2db3273b3d8f.mov

023-02-03 at 14.49.07.mov

https://user-images.githubusercontent.com/66784492/216525807-27ae9368-7c0d-402e-ab1e-e31238710bd8.mov

